### PR TITLE
16.0 fix llm thread switching bug

### DIFF
--- a/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.js
+++ b/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.js
@@ -42,6 +42,15 @@ export class LLMChatComposer extends Component {
 
     this.composerView.postUserMessageForAi();
   }
+  /**
+   * Handles click on the stop button.
+   *
+   * @private
+   * @param {MouseEvent} ev
+   */
+  _onClickStop(ev) {
+    this.composerView._stopStreaming();
+  }
 }
 
 Object.assign(LLMChatComposer, {

--- a/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.js
+++ b/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.js
@@ -46,9 +46,8 @@ export class LLMChatComposer extends Component {
    * Handles click on the stop button.
    *
    * @private
-   * @param {MouseEvent} ev
    */
-  _onClickStop(ev) {
+  _onClickStop() {
     this.composerView._stopStreaming();
   }
 }

--- a/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.xml
+++ b/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.xml
@@ -7,13 +7,23 @@
         style="max-width: 1200px;"
       >
                 <LLMChatComposerTextInput record="composerView" />
-                <button
-          class="o_Composer_actionButton o_Composer_button o_Composer_buttonSend btn btn-primary o-last o-composer-is-compact border-start-0"
-          t-on-click="_onClickSend"
-          t-att-disabled="isDisabled"
-        >
-                    <i class="fa fa-paper-plane-o" />
-                </button>
+                <t t-if="!composerView.isStreaming">
+                    <button
+           class="o_Composer_actionButton o_Composer_button o_Composer_buttonSend btn btn-primary o-last o-composer-is-compact border-start-0"
+           t-on-click="_onClickSend"
+           t-att-disabled="isDisabled"
+                    >
+                        <i class="fa fa-paper-plane-o" />
+                    </button>
+                </t>
+                <t t-if="composerView.isStreaming">
+                    <button
+          class="o_Composer_actionButton o_Composer_button o_Composer_buttonStop btn btn-danger o-last o-composer-is-compact border-start-0"
+          t-on-click="_onClickStop"
+         >
+                        <i class="fa fa-stop" />
+                    </button>
+                </t>
             </div>
         </div>
     </t>

--- a/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.xml
+++ b/llm_thread/static/src/components/llm_chat_composer/llm_chat_composer.xml
@@ -9,18 +9,18 @@
                 <LLMChatComposerTextInput record="composerView" />
                 <t t-if="!composerView.isStreaming">
                     <button
-           class="o_Composer_actionButton o_Composer_button o_Composer_buttonSend btn btn-primary o-last o-composer-is-compact border-start-0"
-           t-on-click="_onClickSend"
-           t-att-disabled="isDisabled"
-                    >
+            class="o_Composer_actionButton o_Composer_button o_Composer_buttonSend btn btn-primary o-last o-composer-is-compact border-start-0"
+            t-on-click="_onClickSend"
+            t-att-disabled="isDisabled"
+          >
                         <i class="fa fa-paper-plane-o" />
                     </button>
                 </t>
                 <t t-if="composerView.isStreaming">
                     <button
-          class="o_Composer_actionButton o_Composer_button o_Composer_buttonStop btn btn-danger o-last o-composer-is-compact border-start-0"
-          t-on-click="_onClickStop"
-         >
+            class="o_Composer_actionButton o_Composer_button o_Composer_buttonStop btn btn-danger o-last o-composer-is-compact border-start-0"
+            t-on-click="_onClickStop"
+          >
                         <i class="fa fa-stop" />
                     </button>
                 </t>

--- a/llm_thread/static/src/models/composer_view.js
+++ b/llm_thread/static/src/models/composer_view.js
@@ -142,7 +142,8 @@ registerPatch({
       // Close the active EventSource connection if it exists
       if (this.eventSource) {
         this.eventSource.close();
-        this.update({ eventSource: undefined }); // Clear the reference
+        // Clear the reference
+        this.update({ eventSource: undefined });
         console.log("EventSource closed by _stopStreaming");
       }
 
@@ -263,7 +264,8 @@ registerPatch({
 
       this.eventSource.onerror = (error) => {
         console.error("EventSource failed:", error);
-        this.eventSource?.close(); // Safely close if it exists
+        // Safely close if it exists
+        this.eventSource?.close();
         // Ensure state is fully stopped and reference is cleared
         this._stopStreaming();
       };

--- a/llm_thread/static/src/models/composer_view.js
+++ b/llm_thread/static/src/models/composer_view.js
@@ -191,7 +191,11 @@ registerPatch({
       });
 
       // Store the EventSource instance on the model
-      this.update({ eventSource: new EventSource(`/llm/thread/stream_response?thread_id=${composer.thread.id}`) });
+      this.update({
+        eventSource: new EventSource(
+          `/llm/thread/stream_response?thread_id=${composer.thread.id}`
+        ),
+      });
 
       this.eventSource.onmessage = async (event) => {
         const data = JSON.parse(event.data);

--- a/llm_thread/static/src/models/llm_chat_view.js
+++ b/llm_thread/static/src/models/llm_chat_view.js
@@ -18,6 +18,18 @@ registerModel({
      * @private
      */
     _onLLMChatActiveThreadChanged() {
+      const currentActiveThread = this.llmChat.activeThread;
+
+      // Also check and stop streaming on the *current* thread if it happens to be streaming
+      if (currentActiveThread) {
+        const currentThreadView = currentActiveThread.threadViews?.[0];
+        const currentComposerView = currentThreadView?.composerView;
+        if (currentComposerView?.isStreaming) {
+          currentComposerView._stopStreaming();
+        }
+      }
+
+      // Original logic to update router state
       this.env.services.router.pushState({
         action: this.llmChat.llmChatView.actionId,
         active_id: this.llmChat.activeId,


### PR DESCRIPTION
Took a while to figure out the issue. While this works, I have not yet been able to figure out why each `Thread` does not have a separate `ComposerView`. I found out that there is a shared `ComposerView` that is in action with all the Threads. It could be coming from the `mail` module, or maybe some wrong relation in our module, but I could not figure it out.

For now, it works to stop streaming when `activeThread` changes, also added a stop button that does the same thing.