### PR TITLE
16.0.fal.ai.training

### DIFF
--- a/llm_training/__manifest__.py
+++ b/llm_training/__manifest__.py
@@ -12,13 +12,15 @@
     "website": "https://github.com/apexive/odoo-llm",
     "category": "Technical",
     "version": "16.0.1.0.0",
-    "depends": ["base", "mail", "llm"],
+    "depends": ["base", "mail", "llm", "llm_thread", "llm_assistant", "llm_prompt", "llm_fal_ai"],
     "data": [
         "security/llm_training_security.xml",
         "security/ir.model.access.csv",
         "views/llm_training_dataset_views.xml",
         "views/llm_training_job_views.xml",
+        "views/llm_training_job_avatar_views.xml",
         "views/llm_training_menu_views.xml",
+        "views/llm_thread_training_views.xml",
     ],
     "images": [
         "static/description/banner.jpeg",

--- a/llm_training/models/__init__.py
+++ b/llm_training/models/__init__.py
@@ -1,3 +1,4 @@
 from . import llm_training_dataset
 from . import llm_training_job
 from . import llm_provider
+from . import llm_thread

--- a/llm_training/models/llm_thread.py
+++ b/llm_training/models/llm_thread.py
@@ -56,8 +56,8 @@ class LLMThread(models.Model):
                 # Only post error if force is True (user explicitly requested training)
                 if force:
                     self._post_training_error_message(
-                        "Error: El modelo seleccionado no es compatible con generación de imágenes. "
-                        "Por favor selecciona un modelo con model_use = 'image_generation' para entrenar avatares."
+                        "Error: The selected model does not support image generation. "
+                        "Please select a model with model_use = 'image_generation' to train avatars."
                     )
                 return
             
@@ -70,8 +70,8 @@ class LLMThread(models.Model):
             if not user_messages:
                 if force:
                     self._post_training_error_message(
-                        "Error: No se encontraron mensajes de usuario con imágenes. "
-                        "Por favor agrega algunas imágenes a los mensajes antes de entrenar el avatar."
+                        "Error: No user messages with images found. "
+                        "Please add some images to the messages before training the avatar."
                     )
                 return
             

--- a/llm_training/models/llm_thread.py
+++ b/llm_training/models/llm_thread.py
@@ -1,0 +1,266 @@
+import logging
+import tempfile
+import zipfile
+import os
+import base64
+import requests
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class LLMThread(models.Model):
+    _inherit = "llm.thread"
+
+    # Computed field for zip URL of user image attachments
+    all_user_image_attachments_zip = fields.Char(
+        string="User Images Zip URL",
+        compute="_compute_all_user_image_attachments_zip",
+        help="URL to zip file containing all image attachments from USER messages"
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Override create to trigger avatar training when conditions are met"""
+        threads = super().create(vals_list)
+        
+        # Don't trigger training immediately on create since there are no messages yet
+        # The training will be triggered when messages are added
+        
+        return threads
+
+    def _check_and_create_avatar_training(self, force=False):
+        """Check if thread meets criteria for avatar training and create training job if needed"""
+        try:
+            # Check if thread has an assistant
+            if not self.assistant_id:
+                return
+            
+            # Check if assistant has a prompt with category "train_avatar"
+            assistant = self.assistant_id
+            if not assistant.prompt_id or not assistant.prompt_id.category_id:
+                return
+            
+            # Check if category code is "train_avatar"
+            if assistant.prompt_id.category_id.code != "train_avatar":
+                return
+            
+            # Check if we have a model with image_generation capability
+            model = self.model_id
+            if not model or model.model_use != 'image_generation':
+                _logger.warning(
+                    f"Thread {self.id}: Model {model.name if model else 'None'} "
+                    f"does not support image_generation. Avatar training skipped."
+                )
+                # Only post error if force is True (user explicitly requested training)
+                if force:
+                    self._post_training_error_message(
+                        "Error: El modelo seleccionado no es compatible con generación de imágenes. "
+                        "Por favor selecciona un modelo con model_use = 'image_generation' para entrenar avatares."
+                    )
+                return
+            
+            # Check if we have user messages with image attachments
+            user_messages = self.message_ids.filtered(
+                lambda m:
+                         m.attachment_ids.filtered(lambda a: a.mimetype and a.mimetype.startswith('image/'))
+            )
+            
+            if not user_messages:
+                if force:
+                    self._post_training_error_message(
+                        "Error: No se encontraron mensajes de usuario con imágenes. "
+                        "Por favor agrega algunas imágenes a los mensajes antes de entrenar el avatar."
+                    )
+                return
+            
+            # Check if training job already exists for this thread
+            existing_job = self.env['llm.training.job'].search([
+                ('name', 'ilike', f'Avatar Training - {self.name}'),
+                ('state', 'in', ['draft', 'validating', 'preparing', 'queued', 'training'])
+            ], limit=1)
+            
+            if existing_job:
+                _logger.info(f"Thread {self.id}: Avatar training job already exists ({existing_job.id})")
+                return
+            
+            # Create avatar training job
+            self._create_avatar_training_job(assistant, model)
+            
+        except Exception as e:
+            _logger.error(f"Error checking avatar training conditions for thread {self.id}: {e}")
+
+    def trigger_avatar_training(self):
+        """Manually trigger avatar training for this thread"""
+        self._check_and_create_avatar_training(force=True)
+
+    def _create_avatar_training_job(self, assistant, model):
+        """Create and start avatar training job"""
+        try:
+            # Create training job
+            training_job = self.env['llm.training.job'].create({
+                'name': f"Avatar Training - {self.name}",
+                'description': f"Automatic avatar training for thread {self.name} with assistant {assistant.name}",
+                'provider_id': self.provider_id.id,
+                'base_model_id': model.id,
+                'state': 'draft',
+                'hyperparameters': {
+                    'create_masks': True,
+                    'steps': 1000,
+                    'trigger_word': ""
+                }
+            })
+            
+            # Start the avatar training process
+            training_job.start_avatar_training(self, assistant)
+            
+            _logger.info(f"Avatar training job {training_job.id} created for thread {self.id}")
+            
+        except Exception as e:
+            _logger.error(f"Error creating avatar training job for thread {self.id}: {e}")
+            self._post_training_error_message(
+                f"Error al crear el trabajo de entrenamiento: {str(e)}"
+            )
+
+    def _post_message(self, **kwargs):
+        """Override to trigger avatar training when user messages with images are added"""
+        result = super()._post_message(**kwargs)
+        
+        # Check if this is a user message with image attachments
+        subtype_xmlid = kwargs.get('subtype_xmlid')
+        attachment_ids = kwargs.get('attachment_ids', [])
+        
+        if (subtype_xmlid == "llm_mail_message_subtypes.mt_llm_user" and 
+            attachment_ids and 
+            self.assistant_id and 
+            self.assistant_id.prompt_id and 
+            self.assistant_id.prompt_id.category_id and 
+            self.assistant_id.prompt_id.category_id.code == "train_avatar"):
+            
+            # Check if any of the attachments are images
+            has_images = False
+            for attachment_id in attachment_ids:
+                if isinstance(attachment_id, (list, tuple)) and len(attachment_id) > 2:
+                    # Handle [(4, id)] or [(0, 0, values)] format
+                    continue
+                attachment = self.env['ir.attachment'].browse(attachment_id)
+                if attachment.mimetype and attachment.mimetype.startswith('image/'):
+                    has_images = True
+                    break
+            
+            if has_images:
+                # Trigger avatar training check (without delay for simplicity)
+                try:
+                    self._check_and_create_avatar_training()
+                except Exception as e:
+                    _logger.error(f"Error triggering avatar training: {e}")
+        
+        return result
+
+    def _post_training_error_message(self, error_message):
+        """Post error message to thread"""
+        try:
+            self._post_message(
+                subtype_xmlid="llm_mail_message_subtypes.mt_llm_assistant",
+                body=error_message,
+                author_id=False,
+            )
+        except Exception as e:
+            _logger.error(f"Error posting training error message to thread {self.id}: {e}")
+
+    def _compute_all_user_image_attachments_zip(self):
+        """Compute the zip URL for all user image attachments"""
+        for thread in self:
+            thread.all_user_image_attachments_zip = thread._get_user_image_attachments_zip_url()
+
+    def _get_user_image_attachments_zip_url(self):
+        """Get all image attachments from USER messages, create zip, upload to fal.ai, return URL"""
+        try:
+            # Get all USER messages with image attachments
+            user_messages = self.message_ids.filtered(
+                lambda m:   m.attachment_ids
+            )
+            
+            if not user_messages:
+                _logger.info(f"Thread {self.id}: No USER messages with attachments found")
+                return False
+            
+            # Collect all image attachments from USER messages
+            image_attachments = self.env['ir.attachment']
+            for message in user_messages:
+                for attachment in message.attachment_ids:
+                    if attachment.mimetype and attachment.mimetype.startswith('image/'):
+                        image_attachments |= attachment
+            
+            if not image_attachments:
+                _logger.info(f"Thread {self.id}: No image attachments found in USER messages")
+                return False
+            
+            # Create zip file with all images
+            zip_url = self._create_and_upload_images_zip(image_attachments)
+            return zip_url
+            
+        except Exception as e:
+            _logger.error(f"Error creating user image attachments zip for thread {self.id}: {e}")
+            return False
+
+    def _create_and_upload_images_zip(self, image_attachments):
+        """Create a zip file with images and upload to fal.ai"""
+        zip_url = False
+        try:
+            # Create temporary zip file
+            with tempfile.NamedTemporaryFile(suffix='.zip', delete=False) as temp_zip:
+                with zipfile.ZipFile(temp_zip.name, 'w', zipfile.ZIP_DEFLATED) as zipf:
+                    for i, attachment in enumerate(image_attachments):
+                        # Get file extension from mimetype
+                        ext = self._get_extension_from_mimetype(attachment.mimetype)
+                        filename = f"image_{i+1:03d}{ext}"
+                        
+                        # Add image to zip
+                        zipf.writestr(filename, attachment.raw)
+                        _logger.info(f"Added {filename} to zip for thread {self.id}")
+                
+                # Upload zip to fal.ai and get URL
+                zip_url = self._upload_zip_to_fal_ai(temp_zip.name)
+
+            return zip_url
+                
+        except Exception as e:
+            _logger.error(f"Error creating and uploading images zip for thread {self.id}: {e}")
+            raise UserError(f"Error creating images zip: {str(e)}")
+
+    def _get_extension_from_mimetype(self, mimetype):
+        """Get file extension from mimetype"""
+        extensions = {
+            'image/jpeg': '.jpg',
+            'image/jpg': '.jpg',
+            'image/png': '.png',
+            'image/gif': '.gif',
+            'image/webp': '.webp',
+            'image/bmp': '.bmp',
+            'image/tiff': '.tiff'
+        }
+        return extensions.get(mimetype, '.jpg')
+
+    def _upload_zip_to_fal_ai(self, zip_file_path):
+        """Upload zip file to fal.ai and return URL"""
+        try:
+            # Get fal.ai provider
+            fal_ai_provider = self.env['llm.provider'].search([
+                ('service', '=', 'fal_ai')
+            ], limit=1)
+            
+            if not fal_ai_provider:
+                raise UserError("No fal.ai provider configured")
+            
+            # Get fal.ai client
+            fal_client = fal_ai_provider.fal_ai_get_client()
+            
+            # Upload file to fal.ai
+            return fal_client.upload_file(zip_file_path)
+                
+
+        except Exception as e:
+            _logger.error(f"Error uploading zip to fal.ai: {e}")
+            raise UserError(f"Error uploading zip to fal.ai: {str(e)}")

--- a/llm_training/models/llm_training_job.py
+++ b/llm_training/models/llm_training_job.py
@@ -1,5 +1,10 @@
 import json
 import logging
+import base64
+import requests
+import tempfile
+import zipfile
+import os
 
 from odoo import api, fields, models
 from odoo.exceptions import UserError
@@ -187,3 +192,240 @@ class LLMTrainingJob(models.Model):
 
         self.write({"training_metrics": metrics_str})
         return True
+
+    # Avatar training specific methods
+    def start_avatar_training(self, thread, assistant):
+        """Start avatar training workflow for a thread"""
+        try:
+            # Set job state to preparing
+            self.write({'state': 'preparing'})
+            
+            # Get the zip URL for user image attachments
+            zip_url = thread._get_user_image_attachments_zip_url()
+            
+            if not zip_url:
+                raise UserError("No se encontraron imágenes en los mensajes del usuario")
+            
+            # Prepare training parameters using the prompt template
+            training_params = self._prepare_avatar_training_params(assistant, zip_url)
+            
+            # Start the training job
+            self._submit_avatar_training_job(training_params, thread)
+            
+        except Exception as e:
+            _logger.error(f"Error starting avatar training for job {self.id}: {e}")
+            self.write({'state': 'failed'})
+            # Post error message to thread
+            thread._post_training_error_message(
+                f"Error al iniciar el entrenamiento de avatar: {str(e)}"
+            )
+            raise
+
+    def _prepare_avatar_training_params(self, assistant, zip_url):
+        """Prepare training parameters from assistant prompt template"""
+        try:
+            # Get the prompt template
+            prompt_template = assistant.prompt_id.template
+            
+            # Parse the template to extract parameters
+            # The template should contain the JSON structure with placeholders
+            import json
+            
+            # Replace the placeholder with actual zip URL
+            prepared_template = prompt_template.replace(
+                "{{ related_record.all_user_image_attachments_zip }}", 
+                f'"{zip_url}"'
+            )
+            
+            # Parse JSON to validate structure
+            try:
+                training_params = json.loads(prepared_template)
+            except json.JSONDecodeError:
+                # If not valid JSON, create default structure
+                training_params = {
+                    "images_data_url": zip_url,
+                    "create_masks": True,
+                    "steps": 1000,
+                    "trigger_word": ""
+                }
+            
+            # Ensure required fields are present
+            if 'images_data_url' not in training_params:
+                training_params['images_data_url'] = zip_url
+            
+            if 'create_masks' not in training_params:
+                training_params['create_masks'] = True
+                
+            if 'steps' not in training_params:
+                training_params['steps'] = 1000
+                
+            if 'trigger_word' not in training_params:
+                training_params['trigger_word'] = ""
+            
+            return training_params
+            
+        except Exception as e:
+            _logger.error(f"Error preparing avatar training params: {e}")
+            raise UserError(f"Error preparando parámetros de entrenamiento: {str(e)}")
+
+    def _submit_avatar_training_job(self, training_params, thread):
+        """Submit avatar training job to fal.ai"""
+        try:
+            # Get fal.ai provider
+            fal_ai_provider = self.env['llm.provider'].search([
+                ('service', '=', 'fal_ai')
+            ], limit=1)
+            
+            if not fal_ai_provider:
+                raise UserError("No se encontró un proveedor fal.ai configurado")
+            
+            # Get fal.ai client
+            fal_client = fal_ai_provider.fal_ai_get_client()
+            
+            # Set job state to queued
+            self.write({'state': 'queued'})
+            
+            # Submit training job to fal.ai asynchronously
+            # Use commit_asynchronously to run in background
+            self.env.cr.commit()
+            
+            # Run training in a separate method that can be called asynchronously
+            try:
+                self._run_avatar_training_sync(fal_client, training_params, thread.id)
+            except Exception as e:
+                _logger.error(f"Error in synchronous training: {e}")
+                # Try to continue with async processing
+                self.with_context(async_mode=True)._run_avatar_training_async(fal_client, training_params, thread.id)
+            
+            _logger.info(f"Avatar training job {self.id} submitted successfully")
+            
+        except Exception as e:
+            _logger.error(f"Error submitting avatar training job {self.id}: {e}")
+            self.write({'state': 'failed'})
+            raise
+
+    def _run_avatar_training_sync(self, fal_client, training_params, thread_id):
+        """Run avatar training synchronously"""
+        try:
+            # Set job state to training
+            self.write({'state': 'training'})
+            
+            # Submit training job to fal.ai
+            result = fal_client.subscribe(
+                "fal-ai/flux-lora-fast-training",
+                arguments=training_params,
+                with_logs=True,
+            )
+            
+            if not result:
+                raise UserError("No se recibió respuesta del entrenamiento")
+            
+            # Process training result
+            self._process_avatar_training_result(result, thread_id)
+            
+        except Exception as e:
+            _logger.error(f"Error running avatar training sync for job {self.id}: {e}")
+            self.write({'state': 'failed'})
+            
+            # Post error message to thread
+            thread = self.env['llm.thread'].browse(thread_id)
+            if thread.exists():
+                thread._post_training_error_message(
+                    f"Error durante el entrenamiento: {str(e)}"
+                )
+            raise
+
+    @api.model
+    def _run_avatar_training_async(self, fal_client, training_params, thread_id):
+        """Run avatar training asynchronously"""
+        try:
+            # Set job state to training
+            self.write({'state': 'training'})
+            
+            # Submit training job to fal.ai
+            result = fal_client.subscribe(
+                "fal-ai/flux-lora-fast-training",
+                arguments=training_params,
+                with_logs=True,
+            )
+            
+            if not result:
+                raise UserError("No se recibió respuesta del entrenamiento")
+            
+            # Process training result
+            self._process_avatar_training_result(result, thread_id)
+            
+        except Exception as e:
+            _logger.error(f"Error running avatar training async for job {self.id}: {e}")
+            self.write({'state': 'failed'})
+            
+            # Post error message to thread
+            thread = self.env['llm.thread'].browse(thread_id)
+            if thread.exists():
+                thread._post_training_error_message(
+                    f"Error durante el entrenamiento: {str(e)}"
+                )
+
+    def _process_avatar_training_result(self, result, thread_id):
+        """Process the training result and post to thread"""
+        try:
+            # Get thread
+            thread = self.env['llm.thread'].browse(thread_id)
+            if not thread.exists():
+                raise UserError(f"Thread {thread_id} no encontrado")
+            
+            # Extract model file from result
+            if not result.get('diffusers_lora_file'):
+                raise UserError("No se encontró el archivo del modelo LoRA en el resultado")
+            
+            model_file_info = result['diffusers_lora_file']
+            model_url = model_file_info.get('url')
+            model_filename = model_file_info.get('file_name', 'lora_model.safetensors')
+            
+            if not model_url:
+                raise UserError("No se encontró la URL del modelo LoRA")
+            
+            # Download and attach model to thread
+            self._download_and_attach_model(model_url, model_filename, thread)
+            
+            # Update job state
+            self.write({
+                'state': 'completed',
+                'trained_model_name': model_filename
+            })
+            _logger.info(f"Avatar training job {self.id} completed successfully")
+        except Exception as e:
+            _logger.error(f"Error processing avatar training result for job {self.id}: {e}")
+            self.write({'state': 'failed'})
+            raise
+
+    def _download_and_attach_model(self, model_url, model_filename, thread):
+        """Download LoRA model and attach to thread"""
+        try:
+            # Download model file
+            response = requests.get(model_url, stream=True)
+            response.raise_for_status()
+            
+            # Create attachment
+            attachment = self.env['ir.attachment'].create({
+                'name': model_filename,
+                'datas': base64.b64encode(response.content),
+                'res_model': 'llm.thread',
+                'res_id': thread.id,
+                'mimetype': 'application/octet-stream',
+                'description': f'Modelo LoRA entrenado para avatar - Job {self.id}'
+            })
+            
+            # Post message with attachment
+            thread._post_message(
+                subtype_xmlid="llm_mail_message_subtypes.mt_llm_assistant",
+                body=f"Modelo LoRA descargado: {model_filename}",
+                author_id=False,
+                attachment_ids=[attachment.id]
+            )
+            
+            _logger.info(f"Model {model_filename} downloaded and attached to thread {thread.id}")
+            
+        except Exception as e:
+            _logger.error(f"Error downloading and attaching model: {e}")
+            raise UserError(f"Error descargando modelo: {str(e)}")

--- a/llm_training/models/llm_training_job.py
+++ b/llm_training/models/llm_training_job.py
@@ -224,25 +224,7 @@ class LLMTrainingJob(models.Model):
     def _prepare_avatar_training_params(self, assistant, zip_url):
         """Prepare training parameters from assistant prompt template"""
         try:
-            # Get the prompt template
-            prompt_template = assistant.prompt_id.template
-            
-            # Parse the template to extract parameters
-            # The template should contain the JSON structure with placeholders
-            import json
-            
-            # Replace the placeholder with actual zip URL
-            prepared_template = prompt_template.replace(
-                "{{ related_record.all_user_image_attachments_zip }}", 
-                f'"{zip_url}"'
-            )
-            
-            # Parse JSON to validate structure
-            try:
-                training_params = json.loads(prepared_template)
-            except json.JSONDecodeError:
-                # If not valid JSON, create default structure
-                training_params = {
+            training_params = {
                     "images_data_url": zip_url,
                     "create_masks": True,
                     "steps": 1000,
@@ -291,7 +273,7 @@ class LLMTrainingJob(models.Model):
             
             # Run training in a separate method that can be called asynchronously
             try:
-                self._run_avatar_training_sync(fal_client, training_params, thread.id)
+                self._run_avatar_training_sync(fal_client, training_params, thread)
             except Exception as e:
                 _logger.error(f"Error in synchronous training: {e}")
                 # Try to continue with async processing
@@ -304,7 +286,7 @@ class LLMTrainingJob(models.Model):
             self.write({'state': 'failed'})
             raise
 
-    def _run_avatar_training_sync(self, fal_client, training_params, thread_id):
+    def _run_avatar_training_sync(self, fal_client, training_params, thread):
         """Run avatar training synchronously"""
         try:
             # Set job state to training
@@ -312,7 +294,7 @@ class LLMTrainingJob(models.Model):
             
             # Submit training job to fal.ai
             result = fal_client.subscribe(
-                "fal-ai/flux-lora-fast-training",
+                thread.model_id.name,
                 arguments=training_params,
                 with_logs=True,
             )
@@ -321,14 +303,11 @@ class LLMTrainingJob(models.Model):
                 raise UserError("No se recibió respuesta del entrenamiento")
             
             # Process training result
-            self._process_avatar_training_result(result, thread_id)
+            self._process_avatar_training_result(result, thread)
             
         except Exception as e:
             _logger.error(f"Error running avatar training sync for job {self.id}: {e}")
             self.write({'state': 'failed'})
-            
-            # Post error message to thread
-            thread = self.env['llm.thread'].browse(thread_id)
             if thread.exists():
                 thread._post_training_error_message(
                     f"Error durante el entrenamiento: {str(e)}"
@@ -366,14 +345,9 @@ class LLMTrainingJob(models.Model):
                     f"Error durante el entrenamiento: {str(e)}"
                 )
 
-    def _process_avatar_training_result(self, result, thread_id):
+    def _process_avatar_training_result(self, result, thread):
         """Process the training result and post to thread"""
         try:
-            # Get thread
-            thread = self.env['llm.thread'].browse(thread_id)
-            if not thread.exists():
-                raise UserError(f"Thread {thread_id} no encontrado")
-            
             # Extract model file from result
             if not result.get('diffusers_lora_file'):
                 raise UserError("No se encontró el archivo del modelo LoRA en el resultado")

--- a/llm_training/views/llm_thread_training_views.xml
+++ b/llm_training/views/llm_thread_training_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data>
+    <record id="llm_thread_training_view_form" model="ir.ui.view">
+        <field name="name">llm.thread.training.form</field>
+        <field name="model">llm.thread</field>
+        <field name="inherit_id" ref="llm_thread.llm_thread_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header" position="inside">
+                <button name="trigger_avatar_training" type="object" 
+                        string="Training Avatar"
+                        class="btn-primary"
+                        attrs="{'invisible': [('assistant_id', '=', False)]}"
+                        help="Training a LoRA avatar based on images from user messages"/>
+            </xpath>
+        </field>
+    </record>
+</data>

--- a/llm_training/views/llm_training_job_avatar_views.xml
+++ b/llm_training/views/llm_training_job_avatar_views.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data>
+    <record id="llm_training_job_avatar_view_form" model="ir.ui.view">
+        <field name="name">llm.training.job.avatar.form</field>
+        <field name="model">llm.training.job</field>
+        <field name="inherit_id" ref="llm_training.llm_training_job_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='hyperparameters']" position="after">
+                <field name="trained_model_name" readonly="1"/>
+            </xpath>
+            <xpath expr="//field[@name='training_metrics']" position="after">
+                <group string="Avatar Training Info" attrs="{'invisible': [('name', 'not ilike', 'Avatar Training')]}">
+                    <field name="description" readonly="1"/>
+                </group>
+            </xpath>
+        </field>
+    </record>
+</data>


### PR DESCRIPTION
This pull request introduces a new feature for avatar training in the `llm_training` module, which allows generating LoRA-based avatars using user-provided images. Key changes include extending the `llm.thread` model, adding avatar training workflows, and updating views to support this functionality.

### New Avatar Training Feature

#### Model Enhancements:
* Added `llm_thread.py` to extend the `llm.thread` model with avatar training capabilities, including methods to trigger training, validate requirements, and manage training jobs. This includes a computed field for generating a zip URL of user image attachments.
* Updated `llm_training_job.py` to include methods for starting, submitting, and processing avatar training jobs, as well as downloading and attaching trained models.

#### Dependency Updates:
* Updated `__manifest__.py` to include new dependencies (`llm_thread`, `llm_assistant`, `llm_prompt`, `llm_fal_ai`) and added new view files for avatar training.
* Imported the new `llm_thread` model in `models/__init__.py`.

### User Interface Updates

#### Thread View:
* Added a button in the thread form view to manually trigger avatar training, visible only when an assistant is assigned.

#### Training Job View:
* Enhanced the training job form view to display avatar training-specific information, such as the trained model name and description, when applicable.