### PR TITLE
[ADD] Multimodal file support for images, PDFs and text files

### DIFF
--- a/llm/README.md
+++ b/llm/README.md
@@ -169,26 +169,26 @@ The new `llm_role` field provides dramatic performance improvements:
 
 1. **Set up AI Provider:**
 
-   ```
-   Navigate to: LLM → Configuration → Providers
-   Create new provider with API credentials
-   Click "Fetch Models" to import available models
-   ```
+    ```
+    Navigate to: LLM → Configuration → Providers
+    Create new provider with API credentials
+    Click "Fetch Models" to import available models
+    ```
 
 2. **Configure Models:**
 
-   ```
-   Go to: LLM → Configuration → Models
-   Set default models for chat, embedding, etc.
-   Configure model parameters and capabilities
-   ```
+    ```
+    Go to: LLM → Configuration → Models
+    Set default models for chat, embedding, etc.
+    Configure model parameters and capabilities
+    ```
 
 3. **Security Setup:**
-   ```
-   Assign users to LLM User or LLM Manager groups
-   Configure API key access permissions
-   Set up tool consent requirements
-   ```
+    ```
+    Assign users to LLM User or LLM Manager groups
+    Configure API key access permissions
+    Set up tool consent requirements
+    ```
 
 ## Technical Specifications
 
@@ -238,6 +238,33 @@ Enhanced with LLM-specific fields:
 - `body_json`: Structured data for tool messages
 - Computed role from message subtypes
 - AI-specific email handling
+
+### Multimodal Attachments
+
+The module supports sending file attachments to LLM providers via enhanced mail.message:
+
+#### Supported File Types
+
+| Category      | Mimetypes                                                           |
+| ------------- | ------------------------------------------------------------------- |
+| **Images**    | JPEG, PNG, GIF, WebP                                                |
+| **Documents** | PDF                                                                 |
+| **Text**      | Plain text, Markdown, CSV, HTML, CSS, JavaScript, XML, Python, JSON |
+
+#### API Methods
+
+```python
+# Get formatted attachments from a message
+images = message._get_image_attachments()  # Returns list of base64 images
+pdfs = message._get_pdf_attachments()      # Returns list of base64 PDFs
+texts = message._get_text_attachments()    # Returns decoded text content
+
+# Prepare all attachments for multimodal LLM call
+attachments = message._prepare_multimodal_attachments(is_multimodal=True)
+# Returns: {"images": [...], "pdfs": [...], "texts": [...], "has_attachments": bool}
+```
+
+Non-multimodal models automatically skip images/PDFs while still processing text files.
 
 ### Database Schema
 
@@ -303,28 +330,28 @@ thread.message_post(
 
 1. **Create Provider Module:**
 
-   ```python
-   class LLMProvider(models.Model):
-       _inherit = "llm.provider"
+    ```python
+    class LLMProvider(models.Model):
+        _inherit = "llm.provider"
 
-       @api.model
-       def _get_available_services(self):
-           return super()._get_available_services() + [
-               ('my_service', 'My AI Service')
-           ]
-   ```
+        @api.model
+        def _get_available_services(self):
+            return super()._get_available_services() + [
+                ('my_service', 'My AI Service')
+            ]
+    ```
 
 2. **Implement Service Methods:**
 
-   ```python
-   def my_service_chat(self, messages, model=None, **kwargs):
-       """Service-specific chat implementation"""
-       # Implementation details
+    ```python
+    def my_service_chat(self, messages, model=None, **kwargs):
+        """Service-specific chat implementation"""
+        # Implementation details
 
-   def my_service_embedding(self, text, model=None, **kwargs):
-       """Service-specific embedding implementation"""
-       # Implementation details
-   ```
+    def my_service_embedding(self, text, model=None, **kwargs):
+        """Service-specific embedding implementation"""
+        # Implementation details
+    ```
 
 ### Custom Message Handling
 

--- a/llm/__manifest__.py
+++ b/llm/__manifest__.py
@@ -12,7 +12,7 @@
     "author": "Apexive Solutions LLC",
     "website": "https://github.com/apexive/odoo-llm",
     "category": "Technical",
-    "version": "18.0.1.6.0",
+    "version": "18.0.1.7.0",
     "depends": ["mail", "web"],
     "data": [
         "security/llm_security.xml",

--- a/llm/changelog.rst
+++ b/llm/changelog.rst
@@ -2,9 +2,11 @@
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * [ADD] Multimodal file support for images, PDFs, and text files
-* [ADD] New _get_attachments_by_type() method for DRY attachment handling
-* [ADD] New _prepare_multimodal_attachments() method for provider-agnostic attachment preparation
-* [IMP] Refactored attachment methods to use generic base implementation
+* [ADD] New is_error field for excluding error messages from LLM context
+* [ADD] New _get_attachments_by_mimetype() base method for DRY attachment handling
+* [ADD] New _get_unsupported_attachments() for file compatibility validation
+* [ADD] AUDIO/VIDEO/OFFICE_MIMETYPES constants for file type detection
+* [IMP] Refactored _get_image/pdf/text/audio_attachments() to use base method
 
 18.0.1.6.0 (2026-01-07)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/llm/changelog.rst
+++ b/llm/changelog.rst
@@ -1,3 +1,11 @@
+18.0.1.7.0 (2026-01-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [ADD] Multimodal file support for images, PDFs, and text files
+* [ADD] New _get_attachments_by_type() method for DRY attachment handling
+* [ADD] New _prepare_multimodal_attachments() method for provider-agnostic attachment preparation
+* [IMP] Refactored attachment methods to use generic base implementation
+
 18.0.1.6.0 (2026-01-07)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/llm/models/llm_provider.py
+++ b/llm/models/llm_provider.py
@@ -32,7 +32,7 @@ class LLMProvider(models.Model):
         for record in self:
             if record.name and record.name.lower() in existing_names_lower:
                 raise ValidationError(
-                    _("The provider name must be unique (case-insensitive).")
+                    _("The provider name must be unique (case-insensitive)."),
                 )
 
         return True
@@ -54,7 +54,7 @@ class LLMProvider(models.Model):
         if not hasattr(record, service_method):
             raise NotImplementedError(
                 _("Method '%s' not implemented for service '%s' on target '%s'")
-                % (method, self.service, record_name)
+                % (method, self.service, record_name),
             )
 
         return getattr(record, service_method)(*args, **kwargs)
@@ -99,7 +99,8 @@ class LLMProvider(models.Model):
 
         # Normalize prepend_messages for the specific provider format
         prepend_messages = self._dispatch(
-            "normalize_prepend_messages", prepend_messages
+            "normalize_prepend_messages",
+            prepend_messages,
         )
 
         return self._dispatch(
@@ -141,7 +142,7 @@ class LLMProvider(models.Model):
         """
         if isinstance(content, str):
             return content
-        elif isinstance(content, list):
+        if isinstance(content, list):
             return "\n".join(
                 item.get("text", "")
                 for item in content
@@ -168,7 +169,11 @@ class LLMProvider(models.Model):
                 - urls_list: List of dictionaries with URL metadata
         """
         return self._dispatch(
-            "generate", input_data, model=model, stream=stream, **kwargs
+            "generate",
+            input_data,
+            model=model,
+            stream=stream,
+            **kwargs,
         )
 
     def list_models(self, model_id=None):
@@ -183,7 +188,7 @@ class LLMProvider(models.Model):
         wizard = self.env["llm.fetch.models.wizard"].create(
             {
                 "provider_id": self.id,
-            }
+            },
         )
 
         # Get existing models for comparison
@@ -234,7 +239,7 @@ class LLMProvider(models.Model):
                     "details": details,
                     "existing_model_id": existing.id if existing else False,
                     "selected": status in ["new", "modified"],
-                }
+                },
             )
 
         # Create all lines
@@ -308,7 +313,7 @@ class LLMProvider(models.Model):
             return "embedding"
 
         # Priority 2: Multimodal models (advanced capability)
-        elif any(cap in capabilities for cap in ["multimodal", "vision"]):
+        if any(cap in capabilities for cap in ["multimodal", "vision"]):
             return "multimodal"
 
         # Priority 3: Chat models (default for most LLMs)
@@ -332,7 +337,7 @@ class LLMProvider(models.Model):
 
         # Filter for default model of requested type
         default_models = models.filtered(
-            lambda m: m.default and m.model_use == model_use
+            lambda m: m.default and m.model_use == model_use,
         )
 
         if not default_models:
@@ -383,17 +388,23 @@ class LLMProvider(models.Model):
         """Format tools for the specific provider"""
         return self._dispatch("format_tools", tools)
 
-    def format_messages(self, messages, system_prompt=None):
+    def format_messages(self, messages, system_prompt=None, model=None):
         """Format messages for this provider
 
         Args:
             messages: List of messages to format for specific provider, could be mail.message record set or similar data format
             system_prompt: Optional system prompt to include at the beginning of the messages
+            model: llm.model record (to determine if multimodal)
 
         Returns:
             List of formatted messages in provider-specific format
         """
-        return self._dispatch("format_messages", messages, system_prompt=system_prompt)
+        return self._dispatch(
+            "format_messages",
+            messages,
+            system_prompt=system_prompt,
+            model=model,
+        )
 
     def _get_provider_tool_params(self, tools, kwargs):
         """Hook for provider-specific tool parameters."""

--- a/llm/models/mail_message.py
+++ b/llm/models/mail_message.py
@@ -12,6 +12,15 @@ IMAGE_MIMETYPES = (
     "image/webp",
 )
 
+# Magic bytes for image type detection
+IMAGE_MAGIC_BYTES = {
+    b"\x89PNG\r\n\x1a\n": "image/png",
+    b"\xff\xd8\xff": "image/jpeg",
+    b"GIF87a": "image/gif",
+    b"GIF89a": "image/gif",
+    b"RIFF": "image/webp",  # RIFF....WEBP
+}
+
 PDF_MIMETYPES = ("application/pdf",)
 
 TEXT_MIMETYPES = (
@@ -30,6 +39,25 @@ TEXT_MIMETYPES = (
 )
 
 SUPPORTED_IMAGE_MIMETYPES = IMAGE_MIMETYPES
+
+
+def _detect_image_mimetype(raw_bytes):
+    """Detect the real image mimetype from magic bytes.
+
+    Args:
+        raw_bytes: The raw image bytes
+
+    Returns:
+        The detected mimetype or None if not recognized
+    """
+    for magic, mimetype in IMAGE_MAGIC_BYTES.items():
+        if raw_bytes.startswith(magic):
+            # Special check for WebP: must have WEBP after RIFF header
+            if magic == b"RIFF" and len(raw_bytes) >= 12:
+                if raw_bytes[8:12] != b"WEBP":
+                    continue
+            return mimetype
+    return None
 
 
 class MailMessage(models.Model):
@@ -142,18 +170,59 @@ class MailMessage(models.Model):
         return result["mail.message"][0]
 
     def _get_image_attachments(self):
+        """Get image attachments with validated mimetype from magic bytes.
+
+        Returns list of dicts with mimetype (validated), data (base64), and name.
+        The mimetype is detected from the actual image content, not from Odoo's
+        stored mimetype, to ensure compatibility with strict API validators
+        like Anthropic Claude.
+        """
         self.ensure_one()
         images = []
         for att in self.attachment_ids:
             if att.mimetype and att.mimetype in SUPPORTED_IMAGE_MIMETYPES:
                 if att.datas:
-                    images.append(
-                        {
-                            "mimetype": att.mimetype,
-                            "data": att.datas.decode("utf-8"),
-                            "name": att.name or "image",
-                        },
-                    )
+                    # Decode base64 to get raw bytes for magic byte detection
+                    try:
+                        raw_bytes = base64.b64decode(att.datas)
+                        real_mimetype = _detect_image_mimetype(raw_bytes)
+
+                        if real_mimetype:
+                            # Use detected mimetype instead of stored one
+                            if real_mimetype != att.mimetype:
+                                _logger.debug(
+                                    "Image %s: correcting mimetype from %s to %s",
+                                    att.name,
+                                    att.mimetype,
+                                    real_mimetype,
+                                )
+                            images.append(
+                                {
+                                    "mimetype": real_mimetype,
+                                    "data": att.datas.decode("utf-8"),
+                                    "name": att.name or "image",
+                                },
+                            )
+                        else:
+                            # Fallback to stored mimetype if detection fails
+                            _logger.warning(
+                                "Could not detect image type for %s, using stored mimetype %s",
+                                att.name,
+                                att.mimetype,
+                            )
+                            images.append(
+                                {
+                                    "mimetype": att.mimetype,
+                                    "data": att.datas.decode("utf-8"),
+                                    "name": att.name or "image",
+                                },
+                            )
+                    except (ValueError, TypeError) as e:
+                        _logger.warning(
+                            "Failed to process image attachment %s: %s",
+                            att.name,
+                            e,
+                        )
         return images
 
     def _get_pdf_attachments(self):

--- a/llm/models/mail_message.py
+++ b/llm/models/mail_message.py
@@ -1,9 +1,14 @@
 from odoo import api, fields, models, tools
 
+SUPPORTED_IMAGE_MIMETYPES = (
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "image/webp",
+)
+
 
 class MailMessage(models.Model):
-    """Extension of mail.message to handle LLM-specific message subtypes."""
-
     _inherit = "mail.message"
 
     LLM_XMLIDS = (
@@ -51,7 +56,8 @@ class MailMessage(models.Model):
 
         for xmlid in self.LLM_XMLIDS:
             subtype_id = self.env["ir.model.data"]._xmlid_to_res_id(
-                xmlid, raise_if_not_found=False
+                xmlid,
+                raise_if_not_found=False,
             )
             if subtype_id:
                 # Extract clean role name (e.g., 'user' from 'llm.mt_user')
@@ -110,3 +116,18 @@ class MailMessage(models.Model):
         result = store.get_result()
 
         return result["mail.message"][0]
+
+    def _get_image_attachments(self):
+        self.ensure_one()
+        images = []
+        for att in self.attachment_ids:
+            if att.mimetype and att.mimetype in SUPPORTED_IMAGE_MIMETYPES:
+                if att.datas:
+                    images.append(
+                        {
+                            "mimetype": att.mimetype,
+                            "data": att.datas.decode("utf-8"),
+                            "name": att.name or "image",
+                        },
+                    )
+        return images

--- a/llm/models/mail_message.py
+++ b/llm/models/mail_message.py
@@ -238,6 +238,23 @@ class MailMessage(models.Model):
 
         return result["mail.message"][0]
 
+    def _get_attachments_by_mimetype(self, mimetypes):
+        """Get attachments filtered by mimetype.
+
+        Base method for DRY attachment extraction. Returns raw attachment records
+        filtered by the given mimetypes and having data.
+
+        Args:
+            mimetypes: Tuple of mimetype strings to filter by
+
+        Returns:
+            Filtered ir.attachment recordset
+        """
+        self.ensure_one()
+        return self.attachment_ids.filtered(
+            lambda att: att.mimetype and att.mimetype in mimetypes and att.datas,
+        )
+
     def _get_image_attachments(self):
         """Get image attachments with validated mimetype from magic bytes.
 
@@ -246,91 +263,75 @@ class MailMessage(models.Model):
         stored mimetype, to ensure compatibility with strict API validators
         like Anthropic Claude.
         """
-        self.ensure_one()
         images = []
-        for att in self.attachment_ids:
-            if att.mimetype and att.mimetype in SUPPORTED_IMAGE_MIMETYPES:
-                if att.datas:
-                    # Decode base64 to get raw bytes for magic byte detection
-                    try:
-                        raw_bytes = base64.b64decode(att.datas)
-                        real_mimetype = _detect_image_mimetype(raw_bytes)
+        for att in self._get_attachments_by_mimetype(SUPPORTED_IMAGE_MIMETYPES):
+            try:
+                raw_bytes = base64.b64decode(att.datas)
+                real_mimetype = _detect_image_mimetype(raw_bytes)
 
-                        if real_mimetype:
-                            # Use detected mimetype instead of stored one
-                            if real_mimetype != att.mimetype:
-                                _logger.debug(
-                                    "Image %s: correcting mimetype from %s to %s",
-                                    att.name,
-                                    att.mimetype,
-                                    real_mimetype,
-                                )
-                            images.append(
-                                {
-                                    "mimetype": real_mimetype,
-                                    "data": att.datas.decode("utf-8"),
-                                    "name": att.name or "image",
-                                },
-                            )
-                        else:
-                            # Fallback to stored mimetype if detection fails
-                            _logger.warning(
-                                "Could not detect image type for %s, using stored mimetype %s",
-                                att.name,
-                                att.mimetype,
-                            )
-                            images.append(
-                                {
-                                    "mimetype": att.mimetype,
-                                    "data": att.datas.decode("utf-8"),
-                                    "name": att.name or "image",
-                                },
-                            )
-                    except (ValueError, TypeError) as e:
-                        _logger.warning(
-                            "Failed to process image attachment %s: %s",
+                if real_mimetype:
+                    if real_mimetype != att.mimetype:
+                        _logger.debug(
+                            "Image %s: correcting mimetype from %s to %s",
                             att.name,
-                            e,
+                            att.mimetype,
+                            real_mimetype,
                         )
-        return images
-
-    def _get_pdf_attachments(self):
-        self.ensure_one()
-        pdfs = []
-        for att in self.attachment_ids:
-            if att.mimetype and att.mimetype in PDF_MIMETYPES:
-                if att.datas:
-                    pdfs.append(
+                    images.append(
+                        {
+                            "mimetype": real_mimetype,
+                            "data": att.datas.decode("utf-8"),
+                            "name": att.name or "image",
+                        },
+                    )
+                else:
+                    _logger.warning(
+                        "Could not detect image type for %s, using stored mimetype %s",
+                        att.name,
+                        att.mimetype,
+                    )
+                    images.append(
                         {
                             "mimetype": att.mimetype,
                             "data": att.datas.decode("utf-8"),
-                            "name": att.name or "document.pdf",
+                            "name": att.name or "image",
                         },
                     )
-        return pdfs
+            except (ValueError, TypeError) as e:
+                _logger.warning(
+                    "Failed to process image attachment %s: %s",
+                    att.name,
+                    e,
+                )
+        return images
+
+    def _get_pdf_attachments(self):
+        """Get PDF attachments as base64 data."""
+        return [
+            {
+                "mimetype": att.mimetype,
+                "data": att.datas.decode("utf-8"),
+                "name": att.name or "document.pdf",
+            }
+            for att in self._get_attachments_by_mimetype(PDF_MIMETYPES)
+        ]
 
     def _get_text_attachments(self):
-        self.ensure_one()
+        """Get text attachments with decoded content."""
         texts = []
-        for att in self.attachment_ids:
-            if att.mimetype and att.mimetype in TEXT_MIMETYPES:
-                if att.datas:
-                    try:
-                        raw_data = base64.b64decode(att.datas)
-                        content = raw_data.decode("utf-8")
-                        texts.append(
-                            {
-                                "mimetype": att.mimetype,
-                                "content": content,
-                                "name": att.name or "file.txt",
-                            },
-                        )
-                    except (UnicodeDecodeError, ValueError) as e:
-                        _logger.warning(
-                            "Failed to decode text attachment %s: %s",
-                            att.name,
-                            e,
-                        )
+        for att in self._get_attachments_by_mimetype(TEXT_MIMETYPES):
+            try:
+                raw_data = base64.b64decode(att.datas)
+                content = raw_data.decode("utf-8")
+                texts.append(
+                    {
+                        "mimetype": att.mimetype,
+                        "content": content,
+                        "name": att.name or "file.txt",
+                    },
+                )
+            except (UnicodeDecodeError, ValueError) as e:
+                _logger.warning("Failed to decode text attachment %s: %s", att.name, e)
         return texts
 
     def _get_audio_attachments(self):
@@ -339,33 +340,27 @@ class MailMessage(models.Model):
         Returns list of dicts with format (wav, mp3, etc.), data (base64), and name.
         Only for use with OpenAI gpt-4o-audio-preview models.
         """
-        self.ensure_one()
         audios = []
-        for att in self.attachment_ids:
-            if att.mimetype and att.mimetype in AUDIO_MIMETYPES:
-                if att.datas:
-                    try:
-                        raw_bytes = base64.b64decode(att.datas)
-                        audio_format = _detect_audio_format(raw_bytes)
-                        if audio_format:
-                            audios.append(
-                                {
-                                    "format": audio_format,
-                                    "data": att.datas.decode("utf-8"),
-                                    "name": att.name or "audio",
-                                },
-                            )
-                        else:
-                            _logger.warning(
-                                "Could not detect audio format for %s",
-                                att.name,
-                            )
-                    except (ValueError, TypeError) as e:
-                        _logger.warning(
-                            "Failed to process audio attachment %s: %s",
-                            att.name,
-                            e,
-                        )
+        for att in self._get_attachments_by_mimetype(AUDIO_MIMETYPES):
+            try:
+                raw_bytes = base64.b64decode(att.datas)
+                audio_format = _detect_audio_format(raw_bytes)
+                if audio_format:
+                    audios.append(
+                        {
+                            "format": audio_format,
+                            "data": att.datas.decode("utf-8"),
+                            "name": att.name or "audio",
+                        },
+                    )
+                else:
+                    _logger.warning("Could not detect audio format for %s", att.name)
+            except (ValueError, TypeError) as e:
+                _logger.warning(
+                    "Failed to process audio attachment %s: %s",
+                    att.name,
+                    e,
+                )
         return audios
 
     def _get_unsupported_attachments(

--- a/llm/models/mail_message.py
+++ b/llm/models/mail_message.py
@@ -1,11 +1,35 @@
+import base64
+import logging
+
 from odoo import api, fields, models, tools
 
-SUPPORTED_IMAGE_MIMETYPES = (
+_logger = logging.getLogger(__name__)
+
+IMAGE_MIMETYPES = (
     "image/jpeg",
     "image/png",
     "image/gif",
     "image/webp",
 )
+
+PDF_MIMETYPES = ("application/pdf",)
+
+TEXT_MIMETYPES = (
+    "text/plain",
+    "text/markdown",
+    "text/csv",
+    "text/html",
+    "text/css",
+    "text/javascript",
+    "text/xml",
+    "text/x-python",
+    "application/json",
+    "application/xml",
+    "application/javascript",
+    "application/x-python-code",
+)
+
+SUPPORTED_IMAGE_MIMETYPES = IMAGE_MIMETYPES
 
 
 class MailMessage(models.Model):
@@ -131,3 +155,42 @@ class MailMessage(models.Model):
                         },
                     )
         return images
+
+    def _get_pdf_attachments(self):
+        self.ensure_one()
+        pdfs = []
+        for att in self.attachment_ids:
+            if att.mimetype and att.mimetype in PDF_MIMETYPES:
+                if att.datas:
+                    pdfs.append(
+                        {
+                            "mimetype": att.mimetype,
+                            "data": att.datas.decode("utf-8"),
+                            "name": att.name or "document.pdf",
+                        },
+                    )
+        return pdfs
+
+    def _get_text_attachments(self):
+        self.ensure_one()
+        texts = []
+        for att in self.attachment_ids:
+            if att.mimetype and att.mimetype in TEXT_MIMETYPES:
+                if att.datas:
+                    try:
+                        raw_data = base64.b64decode(att.datas)
+                        content = raw_data.decode("utf-8")
+                        texts.append(
+                            {
+                                "mimetype": att.mimetype,
+                                "content": content,
+                                "name": att.name or "file.txt",
+                            },
+                        )
+                    except (UnicodeDecodeError, ValueError) as e:
+                        _logger.warning(
+                            "Failed to decode text attachment %s: %s",
+                            att.name,
+                            e,
+                        )
+        return texts

--- a/llm/models/mail_message.py
+++ b/llm/models/mail_message.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 
-from odoo import api, fields, models, tools
+from odoo import _, api, fields, models, tools
 
 _logger = logging.getLogger(__name__)
 
@@ -22,6 +22,40 @@ IMAGE_MAGIC_BYTES = {
 }
 
 PDF_MIMETYPES = ("application/pdf",)
+
+# Audio mimetypes - only supported by OpenAI gpt-4o-audio-preview models
+AUDIO_MIMETYPES = (
+    "audio/wav",
+    "audio/x-wav",
+    "audio/mpeg",
+    "audio/mp3",
+    "audio/ogg",
+    "audio/flac",
+    "audio/webm",
+    "audio/mp4",
+    "audio/m4a",
+    "audio/x-m4a",
+)
+
+# Video mimetypes - NOT supported by any LLM provider
+VIDEO_MIMETYPES = (
+    "video/mp4",
+    "video/webm",
+    "video/quicktime",
+    "video/x-msvideo",
+    "video/x-matroska",
+    "video/ogg",
+)
+
+# Office document mimetypes - NOT supported via chat API
+OFFICE_MIMETYPES = (
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+)
 
 TEXT_MIMETYPES = (
     "text/plain",
@@ -60,6 +94,34 @@ def _detect_image_mimetype(raw_bytes):
     return None
 
 
+def _detect_audio_format(raw_bytes):
+    """Detect audio format from magic bytes for OpenAI API.
+
+    Args:
+        raw_bytes: The raw audio bytes
+
+    Returns:
+        The format string for OpenAI API (wav, mp3, flac, ogg) or None
+    """
+    # WAV: RIFF....WAVE
+    if raw_bytes[:4] == b"RIFF" and len(raw_bytes) >= 12:
+        if raw_bytes[8:12] == b"WAVE":
+            return "wav"
+    # MP3: ID3 tag or sync bytes
+    if raw_bytes[:3] == b"ID3" or raw_bytes[:2] == b"\xff\xfb":
+        return "mp3"
+    # FLAC
+    if raw_bytes[:4] == b"fLaC":
+        return "flac"
+    # OGG
+    if raw_bytes[:4] == b"OggS":
+        return "ogg"
+    # M4A/MP4 audio
+    if raw_bytes[4:8] == b"ftyp":
+        return "mp4"
+    return None
+
+
 class MailMessage(models.Model):
     _inherit = "mail.message"
 
@@ -76,6 +138,13 @@ class MailMessage(models.Model):
         store=True,
         index=True,  # Add index for better query performance
         help="The LLM role for this message (user, assistant, tool, system)",
+    )
+
+    is_error = fields.Boolean(
+        string="Is Error Message",
+        default=False,
+        index=True,
+        help="Error messages are shown to users but excluded from LLM context",
     )
 
     body_json = fields.Json(
@@ -263,3 +332,115 @@ class MailMessage(models.Model):
                             e,
                         )
         return texts
+
+    def _get_audio_attachments(self):
+        """Get audio attachments with detected format for OpenAI API.
+
+        Returns list of dicts with format (wav, mp3, etc.), data (base64), and name.
+        Only for use with OpenAI gpt-4o-audio-preview models.
+        """
+        self.ensure_one()
+        audios = []
+        for att in self.attachment_ids:
+            if att.mimetype and att.mimetype in AUDIO_MIMETYPES:
+                if att.datas:
+                    try:
+                        raw_bytes = base64.b64decode(att.datas)
+                        audio_format = _detect_audio_format(raw_bytes)
+                        if audio_format:
+                            audios.append(
+                                {
+                                    "format": audio_format,
+                                    "data": att.datas.decode("utf-8"),
+                                    "name": att.name or "audio",
+                                },
+                            )
+                        else:
+                            _logger.warning(
+                                "Could not detect audio format for %s",
+                                att.name,
+                            )
+                    except (ValueError, TypeError) as e:
+                        _logger.warning(
+                            "Failed to process audio attachment %s: %s",
+                            att.name,
+                            e,
+                        )
+        return audios
+
+    def _get_unsupported_attachments(
+        self,
+        provider_service,
+        is_multimodal=False,
+    ):
+        """Get list of attachments not supported by the current provider/model.
+
+        This method supports both single messages and recordsets, which is essential
+        for validating the ENTIRE conversation context before sending to the LLM.
+
+        Why check the full context?
+        ---------------------------
+        When a user switches LLM models mid-conversation, previously valid attachments
+        may become incompatible. For example:
+        - User sends image to multimodal model → works
+        - User switches to text-only model → images in context unsupported
+
+        Supported file types:
+        - Images (JPEG, PNG, GIF, WebP) - requires multimodal model
+        - PDFs - requires multimodal model
+        - Text files (plain text, markdown, code) - always supported
+
+        Unsupported (user is notified, file skipped):
+        - Audio files - not yet implemented
+        - Video files - not supported by any LLM
+        - Office documents (Word, Excel, PPT) - must convert to PDF first
+
+        The notification message has is_error=True so it's excluded from
+        future LLM context, allowing the conversation to continue normally.
+
+        Args:
+            provider_service: The provider service name (e.g., 'anthropic', 'openai')
+            is_multimodal: Whether the model supports images/PDFs
+
+        Returns:
+            List of dicts with name, mimetype, and reason for each unsupported attachment
+        """
+        unsupported = []
+
+        for message in self:
+            for att in message.attachment_ids:
+                if not att.mimetype or not att.datas:
+                    continue
+
+                mimetype = att.mimetype
+                reason = None
+
+                # Video - never supported by any LLM
+                if mimetype in VIDEO_MIMETYPES:
+                    reason = _("Video files are not supported")
+
+                # Office documents - must convert to PDF
+                elif mimetype in OFFICE_MIMETYPES:
+                    reason = _("Office documents must be converted to PDF first")
+
+                # Audio - not yet implemented
+                elif mimetype in AUDIO_MIMETYPES:
+                    reason = _("Audio files are not yet supported")
+
+                # Images/PDFs - only with multimodal models
+                elif mimetype in IMAGE_MIMETYPES and not is_multimodal:
+                    reason = _("This model does not support images")
+
+                elif mimetype in PDF_MIMETYPES and not is_multimodal:
+                    reason = _("This model does not support PDFs")
+
+                if reason:
+                    unsupported.append(
+                        {
+                            "name": att.name,
+                            "mimetype": mimetype,
+                            "reason": reason,
+                        },
+                    )
+
+        return unsupported

--- a/llm_anthropic/README.md
+++ b/llm_anthropic/README.md
@@ -70,6 +70,39 @@ odoo-bin -d your_db -i llm_assistant,llm_anthropic
 - Multimodal (vision) capabilities for supported models
 - Automatic model discovery
 
+## Multimodal Support
+
+Claude models support sending images and PDFs along with text messages.
+
+### How to Use
+
+1. Attach files (images, PDFs, text files) to your chat message
+2. The module automatically:
+    - Converts images to base64 for Claude's vision API
+    - Sends PDFs as document blocks
+    - Includes text file contents in the message
+
+### Supported Formats
+
+| Type   | Formats                           | Claude Format                         |
+| ------ | --------------------------------- | ------------------------------------- |
+| Images | JPEG, PNG, GIF, WebP              | `type: "image"` with base64 source    |
+| PDFs   | application/pdf                   | `type: "document"` with base64 source |
+| Text   | .txt, .md, .csv, .py, .json, etc. | Appended to message text              |
+
+### Example
+
+```python
+# Attach an image to the chat thread
+thread.message_post(
+    body="What's in this image?",
+    attachment_ids=[(4, image_attachment.id)]
+)
+# Claude will analyze the image and respond
+```
+
+**Note:** Non-multimodal models (like older Claude versions) will skip images/PDFs automatically.
+
 ## Configuration
 
 1. Install the module

--- a/llm_anthropic/__manifest__.py
+++ b/llm_anthropic/__manifest__.py
@@ -18,7 +18,7 @@
     ],
     "website": "https://github.com/apexive/odoo-llm",
     "category": "Technical",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.1.0",
     "depends": ["llm", "llm_tool"],
     "external_dependencies": {
         "python": ["anthropic"],

--- a/llm_anthropic/changelog.rst
+++ b/llm_anthropic/changelog.rst
@@ -1,3 +1,10 @@
+18.0.1.1.0 (2026-01-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [ADD] Multimodal file support for images, PDFs, and text files
+* [IMP] Refactored to use base module's _prepare_multimodal_attachments() method
+* [IMP] Removed duplicate attachment handling code
+
 18.0.1.0.1 (2026-01-07)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/llm_anthropic/models/anthropic_provider.py
+++ b/llm_anthropic/models/anthropic_provider.py
@@ -37,9 +37,7 @@ class LLMProvider(models.Model):
         normalized = []
         for msg in prepend_messages:
             content = msg.get("content", "")
-            if isinstance(content, str):
-                normalized.append({"role": msg["role"], "content": content})
-            elif isinstance(content, list):
+            if isinstance(content, str) or isinstance(content, list):
                 normalized.append({"role": msg["role"], "content": content})
             else:
                 normalized.append(msg)
@@ -75,7 +73,7 @@ class LLMProvider(models.Model):
             Generator if streaming, else dict with 'content' and/or 'tool_calls'
         """
         model = self.get_model(model, "chat")
-        formatted_messages = self.format_messages(messages)
+        formatted_messages = self.format_messages(messages, model=model)
 
         system_content = None
         if prepend_messages:
@@ -111,8 +109,7 @@ class LLMProvider(models.Model):
 
         if stream:
             return self._anthropic_stream_response(params)
-        else:
-            return self._anthropic_process_response(params)
+        return self._anthropic_process_response(params)
 
     def _anthropic_process_response(self, params):
         """Process non-streaming response from Anthropic.
@@ -140,7 +137,7 @@ class LLMProvider(models.Model):
                             "name": block.name,
                             "arguments": json.dumps(block.input),
                         },
-                    }
+                    },
                 )
 
         if thinking_content:
@@ -198,8 +195,8 @@ class LLMProvider(models.Model):
                                         "name": tc["name"],
                                         "arguments": json.dumps(parsed_input),
                                     },
-                                }
-                            ]
+                                },
+                            ],
                         }
                         del tool_calls[event.index]
 
@@ -240,12 +237,12 @@ class LLMProvider(models.Model):
                         "properties": schema.get("properties", {}),
                         "required": schema.get("required", []),
                     },
-                }
+                },
             )
 
         return formatted
 
-    def anthropic_format_messages(self, messages, system_prompt=None):
+    def anthropic_format_messages(self, messages, system_prompt=None, model=None):
         """Format mail.message records for Anthropic API.
 
         Note: System prompts are handled separately in anthropic_chat(),
@@ -254,19 +251,25 @@ class LLMProvider(models.Model):
         Args:
             messages: mail.message recordset
             system_prompt: Optional system prompt (handled separately)
+            model: llm.model record (to determine if multimodal)
 
         Returns:
             List of formatted messages for Anthropic
         """
+        is_multimodal = model and model.model_use == "multimodal"
         formatted_messages = []
 
         for message in messages:
-            formatted_message = self._dispatch("format_message", record=message)
+            formatted_message = self._dispatch(
+                "format_message",
+                record=message,
+                is_multimodal=is_multimodal,
+            )
             if formatted_message:
                 formatted_messages.append(formatted_message)
 
         formatted_messages = self._anthropic_merge_consecutive_user_messages(
-            formatted_messages
+            formatted_messages,
         )
 
         return formatted_messages
@@ -291,11 +294,11 @@ class LLMProvider(models.Model):
                     merged[-1]["content"] = prev_content + curr_content
                 elif isinstance(prev_content, str) and isinstance(curr_content, list):
                     merged[-1]["content"] = [
-                        {"type": "text", "text": prev_content}
+                        {"type": "text", "text": prev_content},
                     ] + curr_content
                 elif isinstance(prev_content, list) and isinstance(curr_content, str):
                     merged[-1]["content"] = prev_content + [
-                        {"type": "text", "text": curr_content}
+                        {"type": "text", "text": curr_content},
                     ]
             else:
                 merged.append(msg)

--- a/llm_anthropic/models/mail_message.py
+++ b/llm_anthropic/models/mail_message.py
@@ -32,14 +32,6 @@ class MailMessage(models.Model):
             else:
                 images = []
                 pdfs = []
-                skipped_images = self._get_image_attachments()
-                skipped_pdfs = self._get_pdf_attachments()
-                if skipped_images or skipped_pdfs:
-                    _logger.debug(
-                        "Skipping %d images and %d PDFs for non-multimodal model",
-                        len(skipped_images),
-                        len(skipped_pdfs),
-                    )
 
             has_attachments = images or pdfs or texts
 

--- a/llm_anthropic/models/mail_message.py
+++ b/llm_anthropic/models/mail_message.py
@@ -23,31 +23,58 @@ class MailMessage(models.Model):
             body = tools.html2plaintext(body)
 
         if self.is_llm_user_message()[self]:
-            if is_multimodal:
-                images = self._get_image_attachments()
-                if images:
-                    content = []
-                    for img in images:
-                        content.append(
-                            {
-                                "type": "image",
-                                "source": {
-                                    "type": "base64",
-                                    "media_type": img["mimetype"],
-                                    "data": img["data"],
-                                },
-                            },
-                        )
-                    if body:
-                        content.append({"type": "text", "text": body})
-                    return {"role": "user", "content": content}
+            images = self._get_image_attachments()
+            pdfs = self._get_pdf_attachments()
+            texts = self._get_text_attachments()
 
-            formatted_message = {"role": "user"}
-            if body:
-                formatted_message["content"] = body
-            else:
-                formatted_message["content"] = ""
-            return formatted_message
+            has_attachments = images or pdfs or texts
+
+            if has_attachments:
+                content = []
+
+                for img in images:
+                    content.append(
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": img["mimetype"],
+                                "data": img["data"],
+                            },
+                        },
+                    )
+
+                for pdf in pdfs:
+                    content.append(
+                        {
+                            "type": "document",
+                            "source": {
+                                "type": "base64",
+                                "media_type": pdf["mimetype"],
+                                "data": pdf["data"],
+                            },
+                        },
+                    )
+
+                text_parts = []
+                if body and body.strip():
+                    text_parts.append(body.strip())
+
+                for txt in texts:
+                    text_parts.append(f"--- {txt['name']} ---\n{txt['content']}")
+
+                if text_parts:
+                    content.append({"type": "text", "text": "\n\n".join(text_parts)})
+                elif images or pdfs:
+                    content.append(
+                        {"type": "text", "text": "Please analyze these files."},
+                    )
+
+                return {"role": "user", "content": content}
+
+            if not body or not body.strip():
+                return None
+            return {"role": "user", "content": body}
 
         if self.is_llm_assistant_message()[self]:
             content_blocks = []
@@ -74,7 +101,7 @@ class MailMessage(models.Model):
 
             if content_blocks:
                 return {"role": "assistant", "content": content_blocks}
-            return {"role": "assistant", "content": ""}
+            return None
 
         if self.is_llm_tool_message()[self]:
             tool_data = self.body_json

--- a/llm_anthropic/models/mail_message.py
+++ b/llm_anthropic/models/mail_message.py
@@ -23,9 +23,23 @@ class MailMessage(models.Model):
             body = tools.html2plaintext(body)
 
         if self.is_llm_user_message()[self]:
-            images = self._get_image_attachments()
-            pdfs = self._get_pdf_attachments()
             texts = self._get_text_attachments()
+
+            # Only include images/PDFs if model supports multimodal
+            if is_multimodal:
+                images = self._get_image_attachments()
+                pdfs = self._get_pdf_attachments()
+            else:
+                images = []
+                pdfs = []
+                skipped_images = self._get_image_attachments()
+                skipped_pdfs = self._get_pdf_attachments()
+                if skipped_images or skipped_pdfs:
+                    _logger.debug(
+                        "Skipping %d images and %d PDFs for non-multimodal model",
+                        len(skipped_images),
+                        len(skipped_pdfs),
+                    )
 
             has_attachments = images or pdfs or texts
 

--- a/llm_anthropic/models/mail_message.py
+++ b/llm_anthropic/models/mail_message.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 class MailMessage(models.Model):
     _inherit = "mail.message"
 
-    def anthropic_format_message(self):
+    def anthropic_format_message(self, is_multimodal=False):
         """Provider-specific formatting for Anthropic Claude.
 
         Key differences from OpenAI:
@@ -23,6 +23,25 @@ class MailMessage(models.Model):
             body = tools.html2plaintext(body)
 
         if self.is_llm_user_message()[self]:
+            if is_multimodal:
+                images = self._get_image_attachments()
+                if images:
+                    content = []
+                    for img in images:
+                        content.append(
+                            {
+                                "type": "image",
+                                "source": {
+                                    "type": "base64",
+                                    "media_type": img["mimetype"],
+                                    "data": img["data"],
+                                },
+                            },
+                        )
+                    if body:
+                        content.append({"type": "text", "text": body})
+                    return {"role": "user", "content": content}
+
             formatted_message = {"role": "user"}
             if body:
                 formatted_message["content"] = body
@@ -30,7 +49,7 @@ class MailMessage(models.Model):
                 formatted_message["content"] = ""
             return formatted_message
 
-        elif self.is_llm_assistant_message()[self]:
+        if self.is_llm_assistant_message()[self]:
             content_blocks = []
 
             if body:
@@ -50,26 +69,25 @@ class MailMessage(models.Model):
                             "id": tc["id"],
                             "name": tc["function"]["name"],
                             "input": tool_input,
-                        }
+                        },
                     )
 
             if content_blocks:
                 return {"role": "assistant", "content": content_blocks}
-            else:
-                return {"role": "assistant", "content": ""}
+            return {"role": "assistant", "content": ""}
 
-        elif self.is_llm_tool_message()[self]:
+        if self.is_llm_tool_message()[self]:
             tool_data = self.body_json
             if not tool_data:
                 _logger.warning(
-                    f"Anthropic Format: Skipping tool message {self.id}: no tool data found."
+                    f"Anthropic Format: Skipping tool message {self.id}: no tool data found.",
                 )
                 return None
 
             tool_call_id = tool_data.get("tool_call_id")
             if not tool_call_id:
                 _logger.warning(
-                    f"Anthropic Format: Skipping tool message {self.id}: missing tool_call_id."
+                    f"Anthropic Format: Skipping tool message {self.id}: missing tool_call_id.",
                 )
                 return None
 
@@ -87,7 +105,7 @@ class MailMessage(models.Model):
                         "type": "tool_result",
                         "tool_use_id": tool_call_id,
                         "content": content,
-                    }
+                    },
                 ],
             }
 

--- a/llm_assistant/models/llm_thread.py
+++ b/llm_assistant/models/llm_thread.py
@@ -192,10 +192,9 @@ class LLMThread(models.Model):
 
         if isinstance(content, list) and len(content) > 0:
             return content[0].get("text", "")
-        elif isinstance(content, str):
+        if isinstance(content, str):
             return content
-        else:
-            return ""
+        return ""
 
     def get_prepend_messages(self):
         """Hook: return a list of formatted messages to prepend to the conversation."""
@@ -209,16 +208,16 @@ class LLMThread(models.Model):
                 _logger.error(
                     "Error getting messages from prompt '%s': %s",
                     self.prompt_id.name,
-                    str(e),
+                    e,
                 )
                 # Continue without prompt messages rather than failing completely
                 # Post a user-friendly warning to the thread
                 self.message_post(
                     body=_(
                         "Note: The prompt '%s' could not be loaded. "
-                        "Continuing without it. (Error: %s)"
+                        "Continuing without it. (Error: %s)",
                     )
-                    % (self.prompt_id.name, str(e))
+                    % (self.prompt_id.name, str(e)),
                 )
 
         return []
@@ -235,7 +234,8 @@ class LLMThread(models.Model):
                 # No DB messages found - check if prepended messages have a user message
                 prepend_msgs = self.get_prepend_messages()
                 user_msg = next(
-                    (msg for msg in prepend_msgs if msg.get("role") == "user"), None
+                    (msg for msg in prepend_msgs if msg.get("role") == "user"),
+                    None,
                 )
 
                 if user_msg:
@@ -269,14 +269,15 @@ class LLMThread(models.Model):
                 tool_calls = last_message.get_tool_calls()
                 for tool_call in tool_calls:
                     tool_message = yield from self._execute_tool_call(
-                        tool_call, last_message
+                        tool_call,
+                        last_message,
                     )
                     last_message = tool_message
                     self.env.cr.commit()
             else:
                 _logger.info(
                     f"Breaking loop. Last message role: {last_message.llm_role}, "
-                    f"has_tool_calls: {last_message.has_tool_calls()}"
+                    f"has_tool_calls: {last_message.has_tool_calls()}",
                 )
                 break
 
@@ -286,7 +287,11 @@ class LLMThread(models.Model):
         raise NotImplementedError
 
     def _generate_assistant_response(self):
-        """Generate assistant response and handle tool calls."""
+        """Generate assistant response and handle tool calls.
+
+        Catches LLM API errors and posts them as error messages in the thread
+        so users can see what went wrong without checking server logs.
+        """
         # Flush any pending writes to ensure latest messages are visible
         self.env.flush_all()
 
@@ -297,16 +302,29 @@ class LLMThread(models.Model):
         use_streaming = getattr(self.model_id, "supports_streaming", True)
 
         chat_kwargs = self._prepare_chat_kwargs(message_history, use_streaming)
-        if use_streaming:
-            # Handle streaming response - process tool calls directly from stream
-            stream_response = self.sudo().model_id.chat(**chat_kwargs)
-            assistant_message = yield from self._handle_streaming_response(
-                stream_response
+
+        try:
+            if use_streaming:
+                # Handle streaming response - process tool calls directly from stream
+                stream_response = self.sudo().model_id.chat(**chat_kwargs)
+                assistant_message = yield from self._handle_streaming_response(
+                    stream_response,
+                )
+            else:
+                # Handle non-streaming response
+                response = self.sudo().model_id.chat(**chat_kwargs)
+                assistant_message = yield from self._handle_non_streaming_response(
+                    response,
+                )
+        except Exception as e:
+            # Post error message to thread so user can see it
+            _logger.exception("LLM API error in thread %s", self.id)
+            error_message, event = self._post_error_message(
+                e,
+                title=_("LLM API Error"),
             )
-        else:
-            # Handle non-streaming response
-            response = self.sudo().model_id.chat(**chat_kwargs)
-            assistant_message = yield from self._handle_non_streaming_response(response)
+            yield event
+            return error_message
 
         return assistant_message
 
@@ -326,6 +344,7 @@ class LLMThread(models.Model):
         - Always returns messages in chronological order (ASC)
         - Limits to the most recent N messages for context window management
         - Uses efficient database queries with proper indexing
+        - Excludes error messages (is_error=True) from context
 
         Args:
             limit (int): Maximum number of recent messages to retrieve (default: 25)
@@ -335,26 +354,29 @@ class LLMThread(models.Model):
         """
         self.ensure_one()
 
-        # Domain for filtering LLM messages only
+        # Domain for filtering LLM messages only (excluding error messages)
         domain = [
             ("model", "=", self._name),
             ("res_id", "=", self.id),
             ("llm_role", "!=", False),  # Only messages with LLM roles
+            ("is_error", "=", False),  # Exclude error messages from LLM context
         ]
 
         if limit:
             # Two-step approach for efficiency:
             # 1. Get the N most recent messages (DESC order)
             recent_messages = self.env["mail.message"].search(
-                domain, order="create_date DESC, write_date DESC, id DESC", limit=limit
+                domain,
+                order="create_date DESC, write_date DESC, id DESC",
+                limit=limit,
             )
             # 2. Sort them chronologically for LLM context (ASC order)
             return recent_messages.sorted(lambda m: (m.create_date, m.write_date, m.id))
-        else:
-            # If no limit, get all messages in chronological order
-            return self.env["mail.message"].search(
-                domain, order="create_date ASC, write_date ASC, id ASC"
-            )
+        # If no limit, get all messages in chronological order
+        return self.env["mail.message"].search(
+            domain,
+            order="create_date ASC, write_date ASC, id ASC",
+        )
 
     def get_latest_llm_message(self):
         """Get the most recent LLM message for flow control.
@@ -374,7 +396,9 @@ class LLMThread(models.Model):
         ]
 
         result = self.env["mail.message"].search(
-            domain, order="create_date DESC, write_date DESC, id DESC", limit=1
+            domain,
+            order="create_date DESC, write_date DESC, id DESC",
+            limit=1,
         )
 
         if not result:
@@ -391,9 +415,9 @@ class LLMThread(models.Model):
         # 1. Last message is user message → generate assistant response
         # 2. Last message is tool message → generate assistant response
         # 3. Last message is assistant with tool calls → execute tools
-        if last_message.llm_role in ("user", "tool"):
-            return True
-        elif last_message.llm_role == "assistant" and last_message.has_tool_calls():
+        if last_message.llm_role in ("user", "tool") or (
+            last_message.llm_role == "assistant" and last_message.has_tool_calls()
+        ):
             return True
 
         return False
@@ -408,7 +432,9 @@ class LLMThread(models.Model):
             # Initialize message on first content
             if message is None and chunk.get("content"):
                 message = self.message_post(
-                    body="Thinking...", llm_role="assistant", author_id=False
+                    body="Thinking...",
+                    llm_role="assistant",
+                    author_id=False,
                 )
                 yield {"type": "message_create", "message": message.to_store_format()}
 
@@ -422,7 +448,7 @@ class LLMThread(models.Model):
             if chunk.get("tool_calls"):
                 collected_tool_calls.extend(chunk["tool_calls"])
                 _logger.debug(
-                    f"Collected {len(chunk['tool_calls'])} tool calls from chunk"
+                    f"Collected {len(chunk['tool_calls'])} tool calls from chunk",
                 )
 
             # Handle errors
@@ -500,7 +526,8 @@ class LLMThread(models.Model):
         try:
             # Create tool message using the post_tool_call method
             tool_msg = self.env["mail.message"].post_tool_call(
-                tool_call, thread_model=self
+                tool_call,
+                thread_model=self,
             )
             yield {"type": "message_create", "message": tool_msg.to_store_format()}
 
@@ -514,7 +541,9 @@ class LLMThread(models.Model):
             # Create error tool message using the new method
             try:
                 error_msg = self.env["mail.message"].create_tool_error_message(
-                    tool_call, str(e), thread_model=self
+                    tool_call,
+                    str(e),
+                    thread_model=self,
                 )
                 yield {
                     "type": "message_create",
@@ -526,7 +555,7 @@ class LLMThread(models.Model):
                 # Yield error event so frontend knows something went wrong
                 yield {
                     "type": "error",
-                    "error": f"Tool execution failed: {str(e)}",
+                    "error": f"Tool execution failed: {e!s}",
                 }
                 # Re-raise the original exception - don't silently return None
                 raise e from e2

--- a/llm_openai/README.md
+++ b/llm_openai/README.md
@@ -65,7 +65,38 @@ odoo-bin -d your_db -i llm_assistant,llm_openai
 - Support for all OpenAI models (GPT-4o, GPT-4, GPT-3.5, etc.)
 - Text embeddings support
 - Function calling capabilities
+- Multimodal (vision) capabilities for GPT-4o and GPT-4 Vision
 - Automatic model discovery
+
+## Multimodal Support (Vision)
+
+GPT-4o and GPT-4 Vision models support image and PDF analysis.
+
+### How to Use
+
+Attach files to your chat message - they're automatically processed:
+
+| Type   | OpenAI Format                     |
+| ------ | --------------------------------- |
+| Images | `type: "image_url"` with data URL |
+| PDFs   | `type: "file"` with file_data     |
+| Text   | Appended to message content       |
+
+### Supported Image Formats
+
+- JPEG, PNG, GIF, WebP
+
+### Example
+
+```python
+# Analyze an image
+thread.message_post(
+    body="Describe this image",
+    attachment_ids=[(4, image_id)]
+)
+```
+
+**Note:** Requires a multimodal-capable model (GPT-4o, GPT-4 Vision).
 
 ## Configuration
 

--- a/llm_openai/__manifest__.py
+++ b/llm_openai/__manifest__.py
@@ -8,7 +8,7 @@
     "author": "Apexive Solutions LLC",
     "website": "https://github.com/apexive/odoo-llm",
     "category": "Technical",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "depends": ["llm", "llm_tool", "llm_training"],
     "external_dependencies": {
         "python": ["openai"],

--- a/llm_openai/changelog.rst
+++ b/llm_openai/changelog.rst
@@ -1,3 +1,10 @@
+18.0.1.4.0 (2026-01-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [ADD] Multimodal file support for images, PDFs, and text files
+* [IMP] Refactored to use base module's _prepare_multimodal_attachments() method
+* [IMP] Removed duplicate attachment handling code
+
 18.0.1.3.0 (2026-01-07)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/llm_openai/models/mail_message.py
+++ b/llm_openai/models/mail_message.py
@@ -9,7 +9,13 @@ _logger = logging.getLogger(__name__)
 class MailMessage(models.Model):
     _inherit = "mail.message"
 
-    def openai_format_message(self, is_multimodal=False):
+    def openai_format_message(self, is_multimodal=False, is_audio_model=False):
+        """Format message for OpenAI API.
+
+        Args:
+            is_multimodal: Whether the model supports images/PDFs
+            is_audio_model: Whether the model supports audio (gpt-4o-audio-preview)
+        """
         self.ensure_one()
         body = self.body
         if body:
@@ -34,7 +40,19 @@ class MailMessage(models.Model):
                         len(skipped_pdfs),
                     )
 
-            has_attachments = images or pdfs or texts
+            # Only include audio if model supports it
+            if is_audio_model:
+                audios = self._get_audio_attachments()
+            else:
+                audios = []
+                skipped_audios = self._get_audio_attachments()
+                if skipped_audios:
+                    _logger.debug(
+                        "Skipping %d audio files for non-audio model",
+                        len(skipped_audios),
+                    )
+
+            has_attachments = images or pdfs or texts or audios
 
             if has_attachments:
                 content = []
@@ -48,7 +66,7 @@ class MailMessage(models.Model):
 
                 if text_parts:
                     content.append({"type": "text", "text": "\n\n".join(text_parts)})
-                elif images or pdfs:
+                elif images or pdfs or audios:
                     content.append(
                         {"type": "text", "text": "Please analyze these files."},
                     )
@@ -70,6 +88,17 @@ class MailMessage(models.Model):
                             "file": {
                                 "filename": pdf["name"],
                                 "file_data": f"data:{pdf['mimetype']};base64,{pdf['data']}",
+                            },
+                        },
+                    )
+
+                for audio in audios:
+                    content.append(
+                        {
+                            "type": "input_audio",
+                            "input_audio": {
+                                "data": audio["data"],
+                                "format": audio["format"],
                             },
                         },
                     )

--- a/llm_openai/models/mail_message.py
+++ b/llm_openai/models/mail_message.py
@@ -16,27 +16,55 @@ class MailMessage(models.Model):
             body = tools.html2plaintext(body)
 
         if self.is_llm_user_message()[self]:
-            if is_multimodal:
-                images = self._get_image_attachments()
-                if images:
-                    content = []
-                    if body:
-                        content.append({"type": "text", "text": body})
-                    for img in images:
-                        content.append(
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:{img['mimetype']};base64,{img['data']}",
-                                },
-                            },
-                        )
-                    return {"role": "user", "content": content}
+            images = self._get_image_attachments()
+            pdfs = self._get_pdf_attachments()
+            texts = self._get_text_attachments()
 
-            formatted_message = {"role": "user"}
-            if body:
-                formatted_message["content"] = body
-            return formatted_message
+            has_attachments = images or pdfs or texts
+
+            if has_attachments:
+                content = []
+
+                text_parts = []
+                if body and body.strip():
+                    text_parts.append(body.strip())
+
+                for txt in texts:
+                    text_parts.append(f"--- {txt['name']} ---\n{txt['content']}")
+
+                if text_parts:
+                    content.append({"type": "text", "text": "\n\n".join(text_parts)})
+                elif images or pdfs:
+                    content.append(
+                        {"type": "text", "text": "Please analyze these files."},
+                    )
+
+                for img in images:
+                    content.append(
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": f"data:{img['mimetype']};base64,{img['data']}",
+                            },
+                        },
+                    )
+
+                for pdf in pdfs:
+                    content.append(
+                        {
+                            "type": "file",
+                            "file": {
+                                "filename": pdf["name"],
+                                "file_data": f"data:{pdf['mimetype']};base64,{pdf['data']}",
+                            },
+                        },
+                    )
+
+                return {"role": "user", "content": content}
+
+            if not body or not body.strip():
+                return None
+            return {"role": "user", "content": body}
 
         if self.is_llm_assistant_message()[self]:
             formatted_message = {"role": "assistant"}

--- a/llm_openai/models/mail_message.py
+++ b/llm_openai/models/mail_message.py
@@ -16,9 +16,23 @@ class MailMessage(models.Model):
             body = tools.html2plaintext(body)
 
         if self.is_llm_user_message()[self]:
-            images = self._get_image_attachments()
-            pdfs = self._get_pdf_attachments()
             texts = self._get_text_attachments()
+
+            # Only include images/PDFs if model supports multimodal
+            if is_multimodal:
+                images = self._get_image_attachments()
+                pdfs = self._get_pdf_attachments()
+            else:
+                images = []
+                pdfs = []
+                skipped_images = self._get_image_attachments()
+                skipped_pdfs = self._get_pdf_attachments()
+                if skipped_images or skipped_pdfs:
+                    _logger.debug(
+                        "Skipping %d images and %d PDFs for non-multimodal model",
+                        len(skipped_images),
+                        len(skipped_pdfs),
+                    )
 
             has_attachments = images or pdfs or texts
 

--- a/llm_openai/models/mail_message.py
+++ b/llm_openai/models/mail_message.py
@@ -31,26 +31,12 @@ class MailMessage(models.Model):
             else:
                 images = []
                 pdfs = []
-                skipped_images = self._get_image_attachments()
-                skipped_pdfs = self._get_pdf_attachments()
-                if skipped_images or skipped_pdfs:
-                    _logger.debug(
-                        "Skipping %d images and %d PDFs for non-multimodal model",
-                        len(skipped_images),
-                        len(skipped_pdfs),
-                    )
 
             # Only include audio if model supports it
             if is_audio_model:
                 audios = self._get_audio_attachments()
             else:
                 audios = []
-                skipped_audios = self._get_audio_attachments()
-                if skipped_audios:
-                    _logger.debug(
-                        "Skipping %d audio files for non-audio model",
-                        len(skipped_audios),
-                    )
 
             has_attachments = images or pdfs or texts or audios
 

--- a/llm_openai/models/mail_message.py
+++ b/llm_openai/models/mail_message.py
@@ -9,20 +9,36 @@ _logger = logging.getLogger(__name__)
 class MailMessage(models.Model):
     _inherit = "mail.message"
 
-    def openai_format_message(self):
-        """Provider-specific formatting for OpenAI."""
+    def openai_format_message(self, is_multimodal=False):
         self.ensure_one()
         body = self.body
         if body:
             body = tools.html2plaintext(body)
 
         if self.is_llm_user_message()[self]:
+            if is_multimodal:
+                images = self._get_image_attachments()
+                if images:
+                    content = []
+                    if body:
+                        content.append({"type": "text", "text": body})
+                    for img in images:
+                        content.append(
+                            {
+                                "type": "image_url",
+                                "image_url": {
+                                    "url": f"data:{img['mimetype']};base64,{img['data']}",
+                                },
+                            },
+                        )
+                    return {"role": "user", "content": content}
+
             formatted_message = {"role": "user"}
             if body:
                 formatted_message["content"] = body
             return formatted_message
 
-        elif self.is_llm_assistant_message()[self]:
+        if self.is_llm_assistant_message()[self]:
             formatted_message = {"role": "assistant"}
 
             formatted_message["content"] = body
@@ -44,18 +60,18 @@ class MailMessage(models.Model):
 
             return formatted_message
 
-        elif self.is_llm_tool_message()[self]:
+        if self.is_llm_tool_message()[self]:
             tool_data = self.body_json
             if not tool_data:
                 _logger.warning(
-                    f"OpenAI Format: Skipping tool message {self.id}: no tool data found."
+                    f"OpenAI Format: Skipping tool message {self.id}: no tool data found.",
                 )
                 return None
 
             tool_call_id = tool_data.get("tool_call_id")
             if not tool_call_id:
                 _logger.warning(
-                    f"OpenAI Format: Skipping tool message {self.id}: missing tool_call_id."
+                    f"OpenAI Format: Skipping tool message {self.id}: missing tool_call_id.",
                 )
                 return None
 
@@ -73,5 +89,4 @@ class MailMessage(models.Model):
                 "content": content,
             }
             return formatted_message
-        else:
-            return None
+        return None

--- a/llm_openai/models/openai_provider.py
+++ b/llm_openai/models/openai_provider.py
@@ -76,13 +76,13 @@ class LLMProvider(models.Model):
                 return self._create_openai_tool_from_schema(schema, tool)
 
             _logger.warning(
-                f"Could not get schema for tool {tool.name}, using fallback"
+                f"Could not get schema for tool {tool.name}, using fallback",
             )
             schema = {"type": "object", "properties": {}, "required": []}
             return self._create_openai_tool_from_schema(schema, tool)
 
         except Exception as e:
-            _logger.error(f"Error formatting tool {tool.name}: {str(e)}", exc_info=True)
+            _logger.error(f"Error formatting tool {tool.name}: {e!s}", exc_info=True)
             schema = {
                 "title": tool.name,
                 "description": tool.description,
@@ -123,7 +123,7 @@ class LLMProvider(models.Model):
         """
         if not schema:
             _logger.warning(
-                f"Could not generate schema for tool {tool.name}, skipping."
+                f"Could not generate schema for tool {tool.name}, skipping.",
             )
             return None
 
@@ -171,8 +171,7 @@ class LLMProvider(models.Model):
         """
         model = self.get_model(model, "chat")
 
-        # Format mail.message records for OpenAI
-        formatted_messages = self.format_messages(messages)
+        formatted_messages = self.format_messages(messages, model=model)
 
         # Prepend messages (system prompts, etc.) if provided
         if prepend_messages:
@@ -199,8 +198,7 @@ class LLMProvider(models.Model):
         # Process the response based on streaming mode
         if not stream:
             return self._openai_process_non_streaming_response(response)
-        else:
-            return self._openai_process_streaming_response(response)
+        return self._openai_process_streaming_response(response)
 
     def _openai_process_non_streaming_response(self, response):
         """Processes OpenAI non-streamed response and returns ONE standardized dict."""
@@ -228,11 +226,10 @@ class LLMProvider(models.Model):
 
             if "content" in result or "tool_calls" in result:
                 return result
-            else:
-                _logger.warning(
-                    "OpenAI non-streaming response had no content or tool calls."
-                )
-                return {}  # Return empty dict if nothing to process
+            _logger.warning(
+                "OpenAI non-streaming response had no content or tool calls.",
+            )
+            return {}  # Return empty dict if nothing to process
 
         except (AttributeError, IndexError, Exception) as e:
             _logger.exception("Error processing OpenAI non-streaming response")
@@ -269,7 +266,9 @@ class LLMProvider(models.Model):
                     for tool_call_chunk in delta.tool_calls:
                         index = tool_call_chunk.index or call_counter
                         assembled_tool_calls = self._update_openai_tool_call_chunk(
-                            assembled_tool_calls, tool_call_chunk, index
+                            assembled_tool_calls,
+                            tool_call_chunk,
+                            index,
                         )
                         call_counter += 1
             if stream_has_tools:
@@ -279,36 +278,37 @@ class LLMProvider(models.Model):
                     for index, call_data in sorted(assembled_tool_calls.items()):
                         if call_data.get("_complete"):
                             tool_call_id = call_data.get("id").strip() or str(
-                                uuid.uuid4()
+                                uuid.uuid4(),
                             )
                             final_tool_calls_list.append(
                                 {
                                     # Generate a UUID for id if it's empty, google apis don't give tool call id for example
                                     "id": tool_call_id,
                                     "type": call_data.get(
-                                        "type", "function"
+                                        "type",
+                                        "function",
                                     ),  # Default type
                                     "function": {
                                         "name": call_data["function"]["name"],
                                         "arguments": call_data["function"]["arguments"],
                                     },
-                                }
+                                },
                             )
                         else:
                             yield {
-                                "error": f"Received incomplete tool call data from provider for tool index {index}."
+                                "error": f"Received incomplete tool call data from provider for tool index {index}.",
                             }
 
                     if final_tool_calls_list:
                         yield {"tool_calls": final_tool_calls_list}
                     elif assembled_tool_calls:
                         _logger.warning(
-                            "Stream indicated tool calls, but none were successfully assembled."
+                            "Stream indicated tool calls, but none were successfully assembled.",
                         )
 
                 elif finish_reason != "error":
                     _logger.warning(
-                        f"OpenAI stream had tool chunks but finished with reason '{finish_reason}'. Not yielding tool calls."
+                        f"OpenAI stream had tool chunks but finished with reason '{finish_reason}'. Not yielding tool calls.",
                     )
 
         except Exception as e:
@@ -343,7 +343,8 @@ class LLMProvider(models.Model):
 
         # Use the common helper to determine completeness for OpenAI
         current_call["_complete"] = self._is_tool_call_complete(
-            current_call["function"], expected_endings=("]", "}")
+            current_call["function"],
+            expected_endings=("]", "}"),
         )
 
         return tool_call_chunks
@@ -365,11 +366,24 @@ class LLMProvider(models.Model):
             for model in models.data:
                 yield self._openai_parse_model(model)
 
+    # OpenAI API doesn't expose capabilities - use pattern matching
+    OPENAI_VISION_PATTERNS = (
+        "gpt-4o",
+        "gpt-4-turbo",
+        "gpt-4.1",
+        "gpt-4-vision",
+        "gpt-5",
+        "o1",
+        "o3",
+    )
+
     def _openai_parse_model(self, model):
-        capabilities = ["chat"]  # default
-        if "text-embedding" in model.id:
+        capabilities = ["chat"]
+        model_id_lower = model.id.lower()
+
+        if "text-embedding" in model_id_lower or "embedding" in model_id_lower:
             capabilities = ["embedding"]
-        elif "gpt-4-vision" in model.id:
+        elif any(p in model_id_lower for p in self.OPENAI_VISION_PATTERNS):
             capabilities = ["chat", "multimodal"]
 
         return {
@@ -399,34 +413,38 @@ class LLMProvider(models.Model):
         verbose_logging = False
 
         validator = OpenAIMessageValidator(
-            messages, logger=_logger, verbose_logging=verbose_logging
+            messages,
+            logger=_logger,
+            verbose_logging=verbose_logging,
         )
         return validator.validate_and_clean()
 
-    def openai_format_messages(self, messages, system_prompt=None):
+    def openai_format_messages(self, messages, system_prompt=None, model=None):
         """Format messages for OpenAI API
 
         Args:
             messages: mail.message recordset to format
             system_prompt: Optional system prompt (deprecated, use prepend_messages)
+            model: llm.model record (to determine if multimodal)
 
         Returns:
             List of formatted messages in OpenAI-compatible format
         """
-        # Format the messages
+        is_multimodal = model and model.model_use == "multimodal"
         formatted_messages = []
 
-        # Add system prompt if provided (for backward compatibility)
         if system_prompt:
             formatted_messages.append({"role": "system", "content": system_prompt})
 
-        # Format the rest of the messages
         for message in messages:
-            formatted_message = self._dispatch("format_message", record=message)
+            formatted_message = self._dispatch(
+                "format_message",
+                record=message,
+                is_multimodal=is_multimodal,
+            )
             if formatted_message:
                 formatted_messages.append(formatted_message)
 
-        # Then validate and clean the messages for OpenAI
         result_messages = self._validate_and_clean_messages(formatted_messages)
 
         return result_messages
@@ -437,7 +455,10 @@ class LLMProvider(models.Model):
         return response
 
     def openai_create_training_job(
-        self, training_file_id, model_name, hyperparameters=None
+        self,
+        training_file_id,
+        model_name,
+        hyperparameters=None,
     ):
         """Create an OpenAI fine-tuning job."""
         self.ensure_one()
@@ -454,7 +475,7 @@ class LLMProvider(models.Model):
             hyperparameters=hyperparams_cleaned if hyperparams_cleaned else None,
         )
         _logger.info(
-            f"Fine-tuning job created successfully for provider '{self.name}'. Job ID: {response.id}"
+            f"Fine-tuning job created successfully for provider '{self.name}'. Job ID: {response.id}",
         )
         return response
 
@@ -474,14 +495,14 @@ class LLMProvider(models.Model):
         """Validate datasets for training"""
         if not job.dataset_ids:
             raise UserError(
-                f"Job '{job.name}': Please select at least one dataset before validating."
+                f"Job '{job.name}': Please select at least one dataset before validating.",
             )
 
         for dataset in job.dataset_ids:
             result = dataset.validate_dataset()
             if not result["valid"]:
                 raise UserError(
-                    f"Validation failed for job '{job.name}':\nDataset '{dataset.name}': {result['message']}"
+                    f"Validation failed for job '{job.name}':\nDataset '{dataset.name}': {result['message']}",
                 )
 
         return True
@@ -497,7 +518,7 @@ class LLMProvider(models.Model):
 
         if not final_combined_bytes:
             raise UserError(
-                f"Job '{job.name}': Combined content from all datasets is empty after processing."
+                f"Job '{job.name}': Combined content from all datasets is empty after processing.",
             )
 
         # Create a filename for the upload (e.g., based on job name or dataset name)
@@ -507,7 +528,8 @@ class LLMProvider(models.Model):
         file_tuple = (upload_filename, file_obj)
 
         file_upload_response = job.provider_id.upload_file(
-            file_tuple, purpose="fine-tune"
+            file_tuple,
+            purpose="fine-tune",
         )
         training_file_id = file_upload_response.id
 
@@ -536,19 +558,19 @@ class LLMProvider(models.Model):
                 dataset_names.append(dataset.name)
             else:
                 _logger.warning(
-                    f"Dataset '{dataset.name}' for job '{job.name}' resulted in empty content, skipping."
+                    f"Dataset '{dataset.name}' for job '{job.name}' resulted in empty content, skipping.",
                 )
 
         if not all_datasets_bytes:
             raise UserError(
-                f"Job '{job.name}': No valid content found in any linked dataset."
+                f"Job '{job.name}': No valid content found in any linked dataset.",
             )
 
         final_combined_bytes = b"".join(all_datasets_bytes)
 
         if not final_combined_bytes:
             raise UserError(
-                f"Job '{self.name}': Combined content from all datasets is empty after processing."
+                f"Job '{self.name}': Combined content from all datasets is empty after processing.",
             )
 
         return final_combined_bytes
@@ -561,7 +583,7 @@ class LLMProvider(models.Model):
         model_dump = response.model_dump()
         if response.status == "succeeded":
             models_data = job.provider_id.list_models(
-                model_id=response.fine_tuned_model
+                model_id=response.fine_tuned_model,
             )
             for model_data in models_data:
                 details = model_data.get("details", {})

--- a/llm_thread/__manifest__.py
+++ b/llm_thread/__manifest__.py
@@ -32,7 +32,7 @@ Use cases include customer support automation, data analysis, training assistanc
 Contact: support@apexive.com
     """,
     "category": "Productivity, Discuss",
-    "version": "18.0.1.4.4",
+    "version": "18.0.1.4.5",
     "depends": ["base", "mail", "web", "llm", "llm_tool"],
     "author": "Apexive Solutions LLC",
     "website": "https://github.com/apexive/odoo-llm",

--- a/llm_thread/__manifest__.py
+++ b/llm_thread/__manifest__.py
@@ -32,7 +32,7 @@ Use cases include customer support automation, data analysis, training assistanc
 Contact: support@apexive.com
     """,
     "category": "Productivity, Discuss",
-    "version": "18.0.1.4.3",
+    "version": "18.0.1.4.4",
     "depends": ["base", "mail", "web", "llm", "llm_tool"],
     "author": "Apexive Solutions LLC",
     "website": "https://github.com/apexive/odoo-llm",

--- a/llm_thread/changelog.rst
+++ b/llm_thread/changelog.rst
@@ -1,3 +1,9 @@
+18.0.1.4.4 (2026-01-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [ADD] Multimodal file attachment support in chat interface
+* [FIX] Restored nginx buffering comment for SSE streaming documentation
+
 18.0.1.4.3 (2025-12-02)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/llm_thread/changelog.rst
+++ b/llm_thread/changelog.rst
@@ -1,4 +1,14 @@
-18.0.1.4.4 (2026-01-17)
+18.0.1.4.5 (2026-01-17)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+* [ADD] Unsupported file detection with is_error message exclusion
+* [ADD] New _post_error_message() for displaying API errors in thread
+* [ADD] New _check_unsupported_attachments() for file compatibility validation
+* [ADD] is_error parameter to message_post() for error message tracking
+* [IMP] Error messages excluded from LLM context via is_error=False filter
+* [IMP] Skip markdown processing for pre-formatted Markup content
+
+18.0.1.4.4 (2026-01-16)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 * [ADD] Multimodal file attachment support in chat interface

--- a/llm_thread/controllers/main.py
+++ b/llm_thread/controllers/main.py
@@ -46,7 +46,7 @@ class LLMThreadController(http.Controller):
             llm_thread = env["llm.thread"].browse(int(thread_id))
             if not llm_thread.exists():
                 yield from cls._safe_yield(
-                    f"data: {json.dumps({'type': 'error', 'error': 'LLM Thread not found.'})}\n\n".encode()
+                    f"data: {json.dumps({'type': 'error', 'error': 'LLM Thread not found.'})}\n\n".encode(),
                 )
                 return
 
@@ -55,7 +55,7 @@ class LLMThreadController(http.Controller):
                 for response in llm_thread.generate(user_message_body, **kwargs):
                     json_data = json.dumps(response, default=str)
                     success = yield from cls._safe_yield(
-                        f"data: {json_data}\n\n".encode()
+                        f"data: {json_data}\n\n".encode(),
                     )
                     if not success:
                         client_connected = False
@@ -66,13 +66,13 @@ class LLMThreadController(http.Controller):
 
             except Exception as e:
                 _logger.exception(
-                    f"Error in llm_thread_generate for thread {thread_id}: {e}"
+                    f"Error in llm_thread_generate for thread {thread_id}: {e}",
                 )
                 # Lock will be automatically released by context manager
 
                 if client_connected:
                     success = yield from cls._safe_yield(
-                        f"data: {json.dumps({'type': 'error', 'error': str(e)})}\n\n".encode()
+                        f"data: {json.dumps({'type': 'error', 'error': str(e)})}\n\n".encode(),
                     )
                     if not success:
                         client_connected = False
@@ -80,20 +80,35 @@ class LLMThreadController(http.Controller):
             finally:
                 if client_connected:
                     yield from cls._safe_yield(
-                        f"data: {json.dumps({'type': 'done'})}\n\n".encode()
+                        f"data: {json.dumps({'type': 'done'})}\n\n".encode(),
                     )
 
     @http.route("/llm/thread/generate", type="http", auth="user", csrf=True)
-    def llm_thread_generate(self, thread_id, message=None, **kwargs):
+    def llm_thread_generate(
+        self,
+        thread_id,
+        message=None,
+        attachment_ids=None,
+        **kwargs,
+    ):
         headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",  # Disable nginx buffering
+            "X-Accel-Buffering": "no",
         }
-        user_message_body = message
+        parsed_attachment_ids = []
+        if attachment_ids:
+            parsed_attachment_ids = [
+                int(x) for x in attachment_ids.split(",") if x.strip().isdigit()
+            ]
         return Response(
             self._llm_thread_generate(
-                request.cr.dbname, request.env, thread_id, user_message_body, **kwargs
+                request.cr.dbname,
+                request.env,
+                thread_id,
+                message,
+                attachment_ids=parsed_attachment_ids,
+                **kwargs,
             ),
             direct_passthrough=True,
             headers=headers,

--- a/llm_thread/controllers/main.py
+++ b/llm_thread/controllers/main.py
@@ -94,7 +94,7 @@ class LLMThreadController(http.Controller):
         headers = {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
+            "X-Accel-Buffering": "no",  # Disable nginx buffering
         }
         parsed_attachment_ids = []
         if attachment_ids:

--- a/llm_thread/models/llm_thread.py
+++ b/llm_thread/models/llm_thread.py
@@ -43,23 +43,25 @@ class RelatedRecordProxy:
                 # Handle different field types
                 if value is None:
                     return default
-                elif isinstance(value, bool):
+                if isinstance(value, bool):
                     return value  # Keep as boolean for Jinja
-                elif hasattr(value, "name"):  # Many2one field
+                if hasattr(value, "name"):  # Many2one field
                     return value.name
-                elif hasattr(value, "mapped"):  # Many2many/One2many field
+                if hasattr(value, "mapped"):  # Many2many/One2many field
                     return value.mapped("name")
-                else:
-                    return value
-            else:
-                _logger.debug(
-                    "Field '%s' not found on record %s", field_name, self._record
-                )
-                return default
+                return value
+            _logger.debug(
+                "Field '%s' not found on record %s",
+                field_name,
+                self._record,
+            )
+            return default
 
         except Exception as e:
             _logger.error(
-                "Error getting field '%s' from record: %s", field_name, str(e)
+                "Error getting field '%s' from record: %s",
+                field_name,
+                e,
             )
             return default
 
@@ -81,9 +83,11 @@ class RelatedRecordProxy:
                 "model": self._record._name,
                 "id": self._record.id,
                 "display_name": getattr(
-                    self._record, "display_name", str(self._record)
+                    self._record,
+                    "display_name",
+                    str(self._record),
                 ),
-            }
+            },
         )
 
     def __repr__(self):
@@ -125,7 +129,8 @@ class LLMThread(models.Model):
 
     # Updated fields for related record reference
     model = fields.Char(
-        string="Related Document Model", help="Technical name of the related model"
+        string="Related Document Model",
+        help="Technical name of the related model",
     )
     res_id = fields.Many2oneReference(
         string="Related Document ID",
@@ -209,7 +214,12 @@ class LLMThread(models.Model):
 
     @api.returns("mail.message", lambda value: value.id)
     def message_post(
-        self, *, llm_role=None, message_type="comment", body_json=None, **kwargs
+        self,
+        *,
+        llm_role=None,
+        message_type="comment",
+        body_json=None,
+        **kwargs,
     ):
         """Override to handle LLM-specific message types and metadata.
 
@@ -230,7 +240,9 @@ class LLMThread(models.Model):
         # Handle LLM-specific subtypes and email_from generation
         if not kwargs.get("author_id") and not kwargs.get("email_from"):
             kwargs["email_from"] = self._get_llm_email_from(
-                kwargs.get("subtype_xmlid"), kwargs.get("author_id"), llm_role
+                kwargs.get("subtype_xmlid"),
+                kwargs.get("author_id"),
+                llm_role,
             )
 
         # Convert markdown to HTML if needed (only for assistant messages)
@@ -257,7 +269,7 @@ class LLMThread(models.Model):
 
         if subtype_xmlid == "llm.mt_tool" or llm_role == "tool":
             return f"Tool <tool@{provider_name.lower().replace(' ', '')}.ai>"
-        elif subtype_xmlid == "llm.mt_assistant" or llm_role == "assistant":
+        if subtype_xmlid == "llm.mt_assistant" or llm_role == "assistant":
             return f"{model_name} <ai@{provider_name.lower().replace(' ', '')}.ai>"
 
         return None
@@ -273,7 +285,11 @@ class LLMThread(models.Model):
     # ============================================================================
 
     def message_post_from_stream(
-        self, stream, llm_role, placeholder_text="…", **kwargs
+        self,
+        stream,
+        llm_role,
+        placeholder_text="…",
+        **kwargs,
     ):
         """Create and update a message from a streaming response.
 
@@ -292,7 +308,10 @@ class LLMThread(models.Model):
             # Initialize message on first content
             if message is None and chunk.get("content"):
                 message = self.message_post(
-                    body=placeholder_text, llm_role=llm_role, author_id=False, **kwargs
+                    body=placeholder_text,
+                    llm_role=llm_role,
+                    author_id=False,
+                    **kwargs,
                 )
                 yield {"type": "message_create", "message": message.to_store_format()}
 
@@ -318,38 +337,39 @@ class LLMThread(models.Model):
     # GENERATION FLOW - Refactored to use message_post with roles
     # ============================================================================
 
-    def generate(self, user_message_body=None, **kwargs):
+    def generate(self, user_message_body=None, attachment_ids=None, **kwargs):
         """Main generation method with PostgreSQL advisory locking.
 
         Args:
             user_message_body: Optional message body. If not provided, will use
                               the latest message in the thread to start generation.
+            attachment_ids: Optional list of ir.attachment IDs to attach to user message.
         """
         self.ensure_one()
 
         with self._generation_lock():
             last_message = False
-            # Post user message if provided
-            if user_message_body:
-                last_message = self.message_post(
-                    body=user_message_body,
-                    llm_role="user",
-                    author_id=self.env.user.partner_id.id,
-                    **kwargs,
-                )
+            if user_message_body or attachment_ids:
+                post_kwargs = {
+                    "body": user_message_body or "",
+                    "llm_role": "user",
+                    "author_id": self.env.user.partner_id.id,
+                }
+                if attachment_ids:
+                    post_kwargs["attachment_ids"] = attachment_ids
+                last_message = self.message_post(**post_kwargs)
                 yield {
                     "type": "message_create",
                     "message": last_message.to_store_format(),
                 }
 
-            # Call the actual generation implementation
             last_message = yield from self.generate_messages(last_message)
             return last_message
 
     def generate_messages(self, last_message=None):
         """Generate messages - to be overridden by llm_assistant module."""
         raise UserError(
-            _("Please install the llm_assistant module for actual AI generation.")
+            _("Please install the llm_assistant module for actual AI generation."),
         )
 
     def get_context(self, base_context=None):
@@ -373,7 +393,10 @@ class LLMThread(models.Model):
                 context["related_res_id"] = None
         except Exception as e:
             _logger.warning(
-                "Error accessing related record %s,%s: %s", self.model, self.res_id, e
+                "Error accessing related record %s,%s: %s",
+                self.model,
+                self.res_id,
+                e,
             )
 
         return context
@@ -395,8 +418,8 @@ class LLMThread(models.Model):
                 raise UserError(
                     _(
                         "This conversation is currently generating a response. "
-                        "Please wait for it to complete before sending another message."
-                    )
+                        "Please wait for it to complete before sending another message.",
+                    ),
                 )
 
             _logger.info(f"Acquired advisory lock for thread {self.id}")
@@ -408,17 +431,19 @@ class LLMThread(models.Model):
             raise UserError(
                 _(
                     "Unable to process your request due to a system conflict. "
-                    "Please wait a moment and try again."
-                )
+                    "Please wait a moment and try again.",
+                ),
             ) from e
         except Exception as e:
             _logger.error(
-                "Unexpected error acquiring lock for thread %s: %s", self.id, e
+                "Unexpected error acquiring lock for thread %s: %s",
+                self.id,
+                e,
             )
             raise UserError(
                 _(
-                    "Your request could not be processed. Please refresh the page and try again."
-                )
+                    "Your request could not be processed. Please refresh the page and try again.",
+                ),
             ) from e
 
     def _release_thread_lock(self):
@@ -517,5 +542,7 @@ class LLMThread(models.Model):
     def _unlink_llm_thread(self):
         unlink_ids = [record.id for record in self]
         self.env["bus.bus"]._sendone(
-            self.env.user.partner_id, "llm.thread/delete", {"ids": unlink_ids}
+            self.env.user.partner_id,
+            "llm.thread/delete",
+            {"ids": unlink_ids},
         )

--- a/llm_thread/models/llm_thread.py
+++ b/llm_thread/models/llm_thread.py
@@ -4,6 +4,7 @@ import logging
 
 import emoji
 import markdown2
+from markupsafe import Markup
 from psycopg2 import OperationalError
 
 from odoo import _, api, fields, models
@@ -219,6 +220,7 @@ class LLMThread(models.Model):
         llm_role=None,
         message_type="comment",
         body_json=None,
+        is_error=False,
         **kwargs,
     ):
         """Override to handle LLM-specific message types and metadata.
@@ -227,6 +229,7 @@ class LLMThread(models.Model):
             llm_role (str): The LLM role ('user', 'assistant', 'tool', 'system')
                            If provided, will automatically set the appropriate subtype
             body_json (dict): JSON body for tool calls - will be set after message creation
+            is_error (bool): If True, marks message as error (excluded from LLM context)
         """
 
         # Convert LLM role to subtype_xmlid if provided
@@ -253,9 +256,14 @@ class LLMThread(models.Model):
         # Create the message using standard mail.thread flow (without body_json)
         message = super().message_post(message_type=message_type, **kwargs)
 
-        # Set body_json after message creation if provided
+        # Set additional fields after message creation
+        write_vals = {}
         if body_json:
-            message.write({"body_json": body_json})
+            write_vals["body_json"] = body_json
+        if is_error:
+            write_vals["is_error"] = True
+        if write_vals:
+            message.write(write_vals)
 
         return message
 
@@ -275,8 +283,11 @@ class LLMThread(models.Model):
         return None
 
     def _process_llm_body(self, body):
-        """Process body content for LLM messages (markdown to HTML conversion)."""
-        if not body:
+        """Process body content for LLM messages (markdown to HTML conversion).
+
+        Skips processing if body is already Markup (pre-formatted HTML).
+        """
+        if not body or isinstance(body, Markup):
             return body
         return markdown2.markdown(emoji.demojize(body))
 
@@ -363,8 +374,149 @@ class LLMThread(models.Model):
                     "message": last_message.to_store_format(),
                 }
 
+                # Check for unsupported attachments in the new message
+                if last_message.attachment_ids:
+                    unsupported = self._check_unsupported_attachments(last_message)
+                    if unsupported:
+                        # Mark the user message as error (excluded from LLM context)
+                        last_message.write({"is_error": True})
+                        # Show warning and return - don't call LLM
+                        yield from self._handle_unsupported_attachments(unsupported)
+                        return last_message
+
             last_message = yield from self.generate_messages(last_message)
             return last_message
+
+    def _get_context_messages(self, limit=25):
+        """Get recent LLM messages that will be sent as context.
+
+        This is used to validate attachments in the ENTIRE context before
+        sending to the LLM, not just the new message.
+
+        Note: Error messages (is_error=True) are excluded from context.
+
+        Args:
+            limit: Maximum number of messages to retrieve (default: 25)
+
+        Returns:
+            mail.message recordset of recent LLM messages
+        """
+        self.ensure_one()
+        domain = [
+            ("model", "=", self._name),
+            ("res_id", "=", self.id),
+            ("llm_role", "!=", False),
+            ("is_error", "=", False),  # Exclude error messages from context
+        ]
+        return self.env["mail.message"].search(
+            domain,
+            order="create_date DESC, id DESC",
+            limit=limit,
+        )
+
+    def _check_unsupported_attachments(self, message=None):
+        """Check a message for unsupported attachments.
+
+        Args:
+            message: Specific message to check. If None, checks entire context.
+
+        Returns:
+            List of unsupported attachments or empty list
+        """
+        self.ensure_one()
+
+        if message:
+            # Check only the specific message
+            messages_to_check = message
+        else:
+            # Check all context messages (for model switch scenarios)
+            context_messages = self._get_context_messages()
+            messages_to_check = context_messages.filtered(
+                lambda m: m.attachment_ids,
+            )
+
+        if not messages_to_check:
+            return []
+
+        provider_service = self.provider_id.service
+        is_multimodal = self.model_id.model_use == "multimodal"
+
+        return messages_to_check._get_unsupported_attachments(
+            provider_service=provider_service,
+            is_multimodal=is_multimodal,
+        )
+
+    def _handle_unsupported_attachments(self, unsupported):
+        """Create an info message for unsupported attachments.
+
+        The message has is_error=True so it's excluded from LLM context,
+        allowing the conversation to continue normally.
+
+        Args:
+            unsupported: List of dicts with name, mimetype, reason
+
+        Yields:
+            Message events for the info message
+        """
+        # Build file list items
+        file_items = "".join(
+            f"<li><strong>{att['name']}</strong>: {att['reason']}</li>"
+            for att in unsupported
+        )
+
+        # Build HTML message
+        error_html = (
+            f"<p>⚠️ <strong>{_('Unsupported file(s)')}</strong></p>"
+            f"<ul>{file_items}</ul>"
+            f"<p><em>{_('These files will be skipped.')}</em></p>"
+        )
+
+        # Post as info message (excluded from LLM context)
+        error_message = self.message_post(
+            body=Markup(error_html),
+            llm_role="assistant",
+            author_id=False,
+            is_error=True,
+        )
+        yield {
+            "type": "message_create",
+            "message": error_message.to_store_format(),
+        }
+        return error_message
+
+    def _post_error_message(self, error, title=None):
+        """Post an error message to the thread (excluded from LLM context).
+
+        This allows users to see API errors directly in the chat instead of
+        only in server logs.
+
+        Args:
+            error: The exception or error string
+            title: Optional title for the error message
+
+        Returns:
+            tuple: (error_message, event_dict) for yielding to the client
+        """
+        title = title or _("Error")
+        error_str = str(error)
+
+        # Build HTML error message
+        error_html = (
+            f"<p>❌ <strong>{title}</strong></p><p><code>{error_str}</code></p>"
+        )
+
+        error_message = self.message_post(
+            body=Markup(error_html),
+            llm_role="assistant",
+            author_id=False,
+            is_error=True,
+        )
+
+        event = {
+            "type": "message_create",
+            "message": error_message.to_store_format(),
+        }
+        return error_message, event
 
     def generate_messages(self, last_message=None):
         """Generate messages - to be overridden by llm_assistant module."""

--- a/llm_thread/static/src/patches/composer_patch.js
+++ b/llm_thread/static/src/patches/composer_patch.js
@@ -12,146 +12,142 @@ import { useState } from "@odoo/owl";
  * All other mail functionality remains unchanged
  */
 patch(Composer.prototype, {
-  setup() {
-    super.setup();
+    setup() {
+        super.setup();
 
-    // Initialize LLM store in setup - wrap with useState for reactivity (like Odoo does)
-    try {
-      this.llmStore = useState(useService("llm.store"));
-    } catch (error) {
-      // LLM service might not be available, that's ok
-      console.warn("LLM store service not available:", error.message);
-      this.llmStore = null;
-    }
-  },
+        // Initialize LLM store in setup - wrap with useState for reactivity (like Odoo does)
+        try {
+            this.llmStore = useState(useService("llm.store"));
+        } catch (error) {
+            // LLM service might not be available, that's ok
+            console.warn("LLM store service not available:", error.message);
+            this.llmStore = null;
+        }
+    },
 
-  /**
-   * Check if current thread is an LLM thread
-   * This is our safety check to ensure we only modify LLM-related behavior
-   */
-  get isLLMThread() {
-    return this.props.composer?.thread?.model === "llm.thread";
-  },
+    /**
+     * Check if current thread is an LLM thread
+     * This is our safety check to ensure we only modify LLM-related behavior
+     */
+    get isLLMThread() {
+        return this.props.composer?.thread?.model === "llm.thread";
+    },
 
-  /**
-   * Check if this LLM thread is currently streaming
-   */
-  get isStreaming() {
-    // Normal mail threads are never "streaming"
-    if (!this.isLLMThread || !this.llmStore) {
-      return false;
-    }
-    return this.llmStore.getStreamingStatus() || false;
-  },
+    /**
+     * Check if this LLM thread is currently streaming
+     */
+    get isStreaming() {
+        // Normal mail threads are never "streaming"
+        if (!this.isLLMThread || !this.llmStore) {
+            return false;
+        }
+        return this.llmStore.getStreamingStatus() || false;
+    },
 
-  get showStop(){
-    if (this.isLLMThread) {
-      return this.isStreaming
-    }
+    get showStop() {
+        if (this.isLLMThread) {
+            return this.isStreaming;
+        }
 
-    return false
-  },
+        return false;
+    },
 
-  /**
-   * Override sendMessage for LLM threads only
-   */
-  async sendMessage() {
-    // For LLM threads, use our custom logic
-    if (this.isLLMThread && this.llmStore) {
-      const content = this.props.composer.text?.trim();
-      if (!content) return;
+    async sendMessage() {
+        if (this.isLLMThread && this.llmStore) {
+            const content = this.props.composer.text?.trim();
+            const attachments = this.props.composer.attachments || [];
+            const attachmentIds = attachments.map((att) => att.id);
 
-      const threadId = this.props.composer.thread.id;
+            if (!content && attachmentIds.length === 0) {
+                return;
+            }
 
-      // Clear composer immediately for better UX
-      this.props.composer.clear();
+            const threadId = this.props.composer.thread.id;
 
-      // Send through LLM store
-      await this.llmStore.sendLLMMessage(threadId, content);
-      return;
-    }
+            this.props.composer.clear();
 
-    // For all other threads, use original mail behavior
-    return super.sendMessage();
-  },
-
-  /**
-   * Override onKeydown to handle LLM-specific shortcuts
-   * @param {KeyboardEvent} ev - Keyboard event
-   */
-  onKeydown(ev) {
-    // LLM-specific handling
-    if (this.isLLMThread) {
-      switch (ev.key) {
-        case "Enter":
-          // For LLM threads, always send on Enter (no Shift+Enter for newline)
-          if (!ev.shiftKey && !this.isStreaming) {
-            ev.preventDefault();
-            this.sendMessage();
+            await this.llmStore.sendLLMMessage(threadId, content, attachmentIds);
             return;
-          }
-          break;
-        case "Escape":
-          // Stop streaming if ESC is pressed
-          if (this.isStreaming) {
-            ev.preventDefault();
-            this.stopStreaming();
-            return;
-          }
-          break;
-      }
-    }
+        }
 
-    // For all other cases (including non-LLM threads), use original behavior
-    super.onKeydown(ev);
-  },
+        return super.sendMessage();
+    },
 
-  /**
-   * Stop LLM streaming (only relevant for LLM threads)
-   */
-  stopStreaming() {
-    if (this.isLLMThread && this.llmStore) {
-      const threadId = this.props.composer.thread.id;
-      this.llmStore.stopStreaming(threadId);
-    }
-  },
+    /**
+     * Override onKeydown to handle LLM-specific shortcuts
+     * @param {KeyboardEvent} ev - Keyboard event
+     */
+    onKeydown(ev) {
+        // LLM-specific handling
+        if (this.isLLMThread) {
+            switch (ev.key) {
+                case "Enter":
+                    // For LLM threads, always send on Enter (no Shift+Enter for newline)
+                    if (!ev.shiftKey && !this.isStreaming) {
+                        ev.preventDefault();
+                        this.sendMessage();
+                        return;
+                    }
+                    break;
+                case "Escape":
+                    // Stop streaming if ESC is pressed
+                    if (this.isStreaming) {
+                        ev.preventDefault();
+                        this.stopStreaming();
+                        return;
+                    }
+                    break;
+            }
+        }
 
-  /**
-   * Override placeholder for LLM threads
-   */
-  get placeholder() {
-    if (this.isLLMThread) {
-      return this.isStreaming
-        ? _t("AI is responding...")
-        : _t("Ask anything...");
-    }
+        // For all other cases (including non-LLM threads), use original behavior
+        super.onKeydown(ev);
+    },
 
-    // Use original placeholder for regular mail
-    return super.placeholder || _t("Write a message...");
-  },
+    /**
+     * Stop LLM streaming (only relevant for LLM threads)
+     */
+    stopStreaming() {
+        if (this.isLLMThread && this.llmStore) {
+            const threadId = this.props.composer.thread.id;
+            this.llmStore.stopStreaming(threadId);
+        }
+    },
 
-  /**
-   * Hide composer avatar/sidebar for LLM threads
-   * This removes the empty 42px column on the left
-   */
-  get showComposerAvatar() {
-    if (this.isLLMThread) {
-      return false;
-    }
+    /**
+     * Override placeholder for LLM threads
+     */
+    get placeholder() {
+        if (this.isLLMThread) {
+            return this.isStreaming ? _t("AI is responding...") : _t("Ask anything...");
+        }
 
-    // Use original logic for regular mail
-    return super.showComposerAvatar;
-  },
+        // Use original placeholder for regular mail
+        return super.placeholder || _t("Write a message...");
+    },
 
-  /**
-   * Disable composer while streaming (LLM only)
-   */
-  get isDisabled() {
-    if (this.isLLMThread) {
-      return this.isStreaming || !this.props.composer.text?.trim();
-    }
+    /**
+     * Hide composer avatar/sidebar for LLM threads
+     * This removes the empty 42px column on the left
+     */
+    get showComposerAvatar() {
+        if (this.isLLMThread) {
+            return false;
+        }
 
-    // Use original disabled logic for regular mail
-    return super.isDisabled;
-  },
+        // Use original logic for regular mail
+        return super.showComposerAvatar;
+    },
+
+    /**
+     * Disable composer while streaming (LLM only)
+     */
+    get isDisabled() {
+        if (this.isLLMThread) {
+            return this.isStreaming || !this.props.composer.text?.trim();
+        }
+
+        // Use original disabled logic for regular mail
+        return super.isDisabled;
+    },
 });

--- a/llm_thread/static/src/services/llm_store_service.js
+++ b/llm_thread/static/src/services/llm_store_service.js
@@ -10,495 +10,480 @@ import { registry } from "@web/core/registry";
  * Provides LLM-specific functionality without breaking mail components
  */
 export const llmStoreService = {
-  dependencies: ["orm", "mail.store", "notification"],
+    dependencies: ["orm", "mail.store", "notification"],
 
-  start(env, { orm, "mail.store": mailStore, notification }) {
-    const llmStore = reactive({
-      // NOTE: Threads are now loaded via standard mail.store, no need for separate Map
-      // Map<id, LLMModel>
-      llmModels: new Map(),
-      // Map<id, LLMProvider>
-      llmProviders: new Map(),
-      // Map<id, LLMTool>
-      llmTools: new Map(),
-      // Set<threadId> currently streaming
-      streamingThreads: new Set(),
-      // Map<threadId, EventSource>
-      eventSources: new Map(),
-      // Resolves when LLM data is loaded
-      isReady: new Deferred(),
-      // Pending AI chat open from client action (bypasses unreliable bus)
-      // { threadId, model, resId, autoGenerate }
-      pendingOpenInChatter: null,
+    start(env, { orm, "mail.store": mailStore, notification }) {
+        const llmStore = reactive({
+            // NOTE: Threads are now loaded via standard mail.store, no need for separate Map
+            // Map<id, LLMModel>
+            llmModels: new Map(),
+            // Map<id, LLMProvider>
+            llmProviders: new Map(),
+            // Map<id, LLMTool>
+            llmTools: new Map(),
+            // Set<threadId> currently streaming
+            streamingThreads: new Set(),
+            // Map<threadId, EventSource>
+            eventSources: new Map(),
+            // Resolves when LLM data is loaded
+            isReady: new Deferred(),
+            // Pending AI chat open from client action (bypasses unreliable bus)
+            // { threadId, model, resId, autoGenerate }
+            pendingOpenInChatter: null,
 
-      // Computed properties - using mailStore as source of truth
-      get activeLLMThread() {
-        // Check if current active thread in mail.store is an LLM thread
-        const activeThread = mailStore.discuss?.thread;
-        return activeThread?.model === "llm.thread" ? activeThread : null;
-      },
+            // Computed properties - using mailStore as source of truth
+            get activeLLMThread() {
+                // Check if current active thread in mail.store is an LLM thread
+                const activeThread = mailStore.discuss?.thread;
+                return activeThread?.model === "llm.thread" ? activeThread : null;
+            },
 
-      get isLLMThread() {
-        return this.activeLLMThread !== null;
-      },
+            get isLLMThread() {
+                return this.activeLLMThread !== null;
+            },
 
-      get llmThreadList() {
-        // Get all LLM threads from mailStore
-        const allThreads = Object.values(mailStore.Thread.records || {});
-        return allThreads
-          .filter((thread) => thread.model === "llm.thread")
-          .sort(
-            (a, b) => new Date(b.write_date || 0) - new Date(a.write_date || 0)
-          );
-      },
+            get llmThreadList() {
+                // Get all LLM threads from mailStore
+                const allThreads = Object.values(mailStore.Thread.records || {});
+                return allThreads
+                    .filter((thread) => thread.model === "llm.thread")
+                    .sort((a, b) => new Date(b.write_date || 0) - new Date(a.write_date || 0));
+            },
 
-      // LLM-specific methods using standard fetchData approach
-      async ensureThreadLoaded(threadId) {
-        // Check if thread already exists in mailStore
-        const thread = mailStore.Thread.get({
-          model: "llm.thread",
-          id: threadId,
+            // LLM-specific methods using standard fetchData approach
+            async ensureThreadLoaded(threadId) {
+                // Check if thread already exists in mailStore
+                const thread = mailStore.Thread.get({
+                    model: "llm.thread",
+                    id: threadId,
+                });
+                if (thread) {
+                    return thread;
+                }
+
+                // If thread not found, it might not be accessible to current user
+                // or wasn't loaded in init_messaging (e.g., old thread, different user)
+                console.warn(`Thread ${threadId} not found in mailStore`);
+                return null;
+            },
+
+            async sendLLMMessage(threadId, content, attachmentIds = []) {
+                if (!threadId || (!content?.trim() && attachmentIds.length === 0)) {
+                    return;
+                }
+
+                try {
+                    await this.startLLMStreaming(threadId, content, attachmentIds);
+                } catch (error) {
+                    console.error("Error sending LLM message:", error);
+                    notification.add(
+                        _t(
+                            "Could not send your message. Please check your connection and try again.",
+                        ),
+                        { type: "danger" },
+                    );
+                }
+            },
+
+            async startLLMStreaming(threadId, message, attachmentIds = []) {
+                this.stopStreaming(threadId);
+
+                this.streamingThreads.add(threadId);
+
+                try {
+                    let url = `/llm/thread/generate?thread_id=${threadId}`;
+                    if (message) {
+                        url += `&message=${encodeURIComponent(message)}`;
+                    }
+                    if (attachmentIds.length > 0) {
+                        url += `&attachment_ids=${attachmentIds.join(",")}`;
+                    }
+                    const eventSource = new EventSource(url);
+
+                    this.eventSources.set(threadId, eventSource);
+
+                    eventSource.onmessage = (event) => {
+                        const data = JSON.parse(event.data);
+                        this.handleStreamMessage(threadId, data);
+                    };
+
+                    eventSource.onerror = (error) => {
+                        console.error("EventSource error:", error);
+                        this.stopStreaming(threadId);
+                        notification.add(
+                            _t(
+                                "Lost connection to AI service. Please try sending your message again.",
+                            ),
+                            {
+                                type: "danger",
+                            },
+                        );
+                    };
+                } catch (error) {
+                    console.error("Error starting stream:", error);
+                    this.stopStreaming(threadId);
+                    notification.add(
+                        _t(
+                            "Could not start AI response. Please check your connection and try again.",
+                        ),
+                        { type: "danger" },
+                    );
+                }
+            },
+
+            stopStreaming(threadId) {
+                const eventSource = this.eventSources.get(threadId);
+                if (eventSource) {
+                    eventSource.close();
+                    this.eventSources.delete(threadId);
+                }
+                this.streamingThreads.delete(threadId);
+            },
+
+            handleStreamMessage(threadId, data) {
+                switch (data.type) {
+                    case "message_create": {
+                        // Handle all messages (user and AI) via EventSource
+                        mailStore.insert({ "mail.message": [data.message] }, { html: true });
+
+                        // Get the created message and add it to the thread's messages collection
+                        const createdMessage = mailStore.Message.get(data.message.id);
+
+                        // Add message to the correct thread's messages collection (not the active thread)
+                        const createThread = mailStore.Thread.get({
+                            model: "llm.thread",
+                            id: threadId,
+                        });
+                        if (
+                            createThread &&
+                            createdMessage &&
+                            !createThread.messages.some((m) => m.id === createdMessage.id)
+                        ) {
+                            createThread.messages.push(createdMessage);
+                        }
+                        break;
+                    }
+
+                    case "message_chunk":
+                    case "message_update":
+                        // Update existing message using standard mail.store.insert() like Odoo does
+                        // Use the same pattern as Odoo's standard bus handlers - always use insert
+                        // which will update existing messages or create new ones as needed
+                        mailStore.insert({ "mail.message": [data.message] }, { html: true });
+                        break;
+
+                    case "error":
+                        console.error("Stream error:", data.error);
+                        this.stopStreaming(threadId);
+                        notification.add(data.error || _t("AI response error"), {
+                            type: "danger",
+                        });
+                        break;
+
+                    case "done":
+                        this.stopStreaming(threadId);
+                        break;
+
+                    case "tool_called":
+                    case "tool_succeeded":
+                    case "tool_failed":
+                        // No-op: handled via message_update
+                        console.log("[LLM] no-op event:", data.type);
+                        break;
+
+                    default:
+                        console.warn("Unknown stream message type:", data.type);
+                        break;
+                }
+            },
+
+            async loadLLMModels() {
+                try {
+                    // Check if llm.model exists first - use correct field names
+                    const models = await orm.searchRead(
+                        "llm.model",
+                        [["active", "=", true]],
+                        ["id", "name", "provider_id", "default", "model_use"],
+                    );
+
+                    models.forEach((model) => {
+                        this.llmModels.set(model.id, model);
+                    });
+                } catch (error) {
+                    console.warn(
+                        "LLM models not available - llm module may not be installed:",
+                        error.message,
+                    );
+                    // Don't throw error, just log warning
+                }
+            },
+
+            async loadLLMProviders() {
+                try {
+                    // Check if llm.provider exists first - use correct field names
+                    const providers = await orm.searchRead(
+                        "llm.provider",
+                        [["active", "=", true]],
+                        ["id", "name", "service"],
+                    );
+
+                    providers.forEach((provider) => {
+                        this.llmProviders.set(provider.id, provider);
+                    });
+                } catch (error) {
+                    console.warn(
+                        "LLM providers not available - llm module may not be installed:",
+                        error.message,
+                    );
+                    // Don't throw error, just log warning
+                }
+            },
+
+            async loadLLMTools() {
+                // Load available tools with minimal fields
+                const tools = await orm.searchRead(
+                    "llm.tool",
+                    [["active", "=", true]],
+                    ["id", "name"],
+                );
+
+                tools.forEach((tool) => {
+                    this.llmTools.set(tool.id, tool);
+                });
+            },
+
+            // Thread selection using standard Odoo patterns
+            async selectThread(threadId) {
+                try {
+                    // Ensure thread is loaded using standard fetchData
+                    const thread = await this.ensureThreadLoaded(threadId);
+                    if (!thread) {
+                        throw new Error("Thread not found or failed to load");
+                    }
+
+                    // Set as active thread in discuss - this is all we need!
+                    thread.setAsDiscussThread();
+                } catch (error) {
+                    console.error("Error selecting thread:", error);
+                    notification.add(
+                        _t(
+                            "Could not load this conversation. It may have been deleted or you may not have access.",
+                        ),
+                        { type: "danger" },
+                    );
+                }
+            },
+
+            // Create new thread with default provider and model
+            async createNewThread({ recordModel, recordId } = {}) {
+                // Get first available provider and model
+                const firstProvider = this.getFirstAvailableProvider();
+                const firstModel = this.getFirstAvailableModel();
+
+                // Check for null values and show notifications
+                if (!firstProvider) {
+                    notification.add(
+                        _t(
+                            "No AI providers are configured. Please contact your administrator to set up an AI provider.",
+                        ),
+                        { type: "danger" },
+                    );
+                    return;
+                }
+
+                if (!firstModel) {
+                    notification.add(
+                        _t(
+                            "No AI models are available. Please contact your administrator to configure AI models.",
+                        ),
+                        { type: "danger" },
+                    );
+                    return;
+                }
+
+                // Create thread with auto-generated name
+                const threadName = `Chat ${new Date().toLocaleString()}`;
+
+                const threadData = {
+                    name: threadName,
+                    provider_id: firstProvider.id,
+                    model_id: firstModel.id,
+                };
+
+                // Auto-link to record if context provided (e.g., from chatter)
+                if (recordModel && recordId) {
+                    threadData.model = recordModel;
+                    threadData.res_id = recordId;
+                }
+
+                const threadId = await orm.call("llm.thread", "create", [threadData]);
+
+                // Reload user threads and select the new one
+                await this.refreshThreadsAndSelect(threadId);
+            },
+
+            // Get first available provider
+            getFirstAvailableProvider() {
+                const providers = Array.from(this.llmProviders.values());
+                return providers.length > 0 ? providers[0] : null;
+            },
+
+            // Get first available model
+            getFirstAvailableModel() {
+                const models = Array.from(this.llmModels.values());
+                return models.length > 0 ? models[0] : null;
+            },
+
+            // Refresh threads and select specific thread
+            async refreshThreadsAndSelect(threadId) {
+                // Use proper fetchData to refresh thread data
+                // Will trigger proper reload of all threads
+                await mailStore.fetchData({
+                    init_messaging: {},
+                });
+
+                // Wait a moment for threads to be populated
+                await new Promise((resolve) => setTimeout(resolve, 100));
+
+                // Select the newly created thread
+                await this.selectThread(threadId);
+            },
+
+            // Link a record to a thread
+            async linkRecordToThread(threadId, model, recordId) {
+                try {
+                    // Update database
+                    await orm.write("llm.thread", [threadId], {
+                        model: model,
+                        res_id: recordId,
+                    });
+
+                    // Update the thread object in mailStore for immediate reactivity
+                    const thread = mailStore.Thread.get({
+                        model: "llm.thread",
+                        id: threadId,
+                    });
+
+                    if (thread) {
+                        Object.assign(thread, {
+                            res_model: model,
+                            res_id: recordId,
+                        });
+                    }
+
+                    notification.add(_t("Record linked to conversation successfully."), {
+                        type: "success",
+                    });
+                    return true;
+                } catch (error) {
+                    console.error("Error linking record:", error);
+                    notification.add(
+                        _t("Could not link the record to this conversation. Please try again."),
+                        { type: "danger" },
+                    );
+                    return false;
+                }
+            },
+
+            // Unlink record from a thread
+            async unlinkRecordFromThread(threadId) {
+                try {
+                    // Update database
+                    await orm.write("llm.thread", [threadId], {
+                        model: false,
+                        res_id: false,
+                    });
+
+                    // Update the thread object in mailStore for immediate reactivity
+                    const thread = mailStore.Thread.get({
+                        model: "llm.thread",
+                        id: threadId,
+                    });
+
+                    if (thread) {
+                        Object.assign(thread, {
+                            res_model: false,
+                            res_id: false,
+                        });
+                    }
+
+                    notification.add(_t("Record unlinked from conversation successfully."), {
+                        type: "success",
+                    });
+                    return true;
+                } catch (error) {
+                    console.error("Error unlinking record:", error);
+                    notification.add(
+                        _t("Could not unlink the record from this conversation. Please try again."),
+                        { type: "danger" },
+                    );
+                    return false;
+                }
+            },
+
+            // Helper methods for components
+            isStreamingThread(threadId) {
+                return this.streamingThreads.has(threadId);
+            },
+
+            getStreamingStatus() {
+                const activeThread = mailStore.discuss?.thread;
+                if (activeThread?.model === "llm.thread") {
+                    return this.isStreamingThread(activeThread.id);
+                }
+                return false;
+            },
+
+            // Pending open methods - used by client action to bypass unreliable bus
+            setPendingOpenInChatter(data) {
+                this.pendingOpenInChatter = data;
+            },
+
+            consumePendingOpenInChatter(model, resId) {
+                const pending = this.pendingOpenInChatter;
+                if (pending && pending.model === model && pending.resId === resId) {
+                    this.pendingOpenInChatter = null;
+                    return pending;
+                }
+                return null;
+            },
+
+            // Get list of data loaders - can be extended by patches
+            getDataLoaders() {
+                return [this.loadLLMProviders, this.loadLLMModels, this.loadLLMTools];
+            },
+
+            // Initialize LLM store - threads now loaded via standard init_messaging
+            async initialize() {
+                try {
+                    const loaders = this.getDataLoaders();
+                    await Promise.all(loaders.map((loader) => loader.call(this)));
+                    // NOTE: LLM threads are now loaded automatically via res.users._init_messaging()
+                    this.isReady.resolve();
+                } catch (error) {
+                    console.error("Error initializing LLM store:", error);
+                    this.isReady.reject(error);
+                }
+            },
+
+            // Cleanup
+            destroy() {
+                // Close all event sources
+                this.eventSources.forEach((eventSource) => eventSource.close());
+                this.eventSources.clear();
+                this.streamingThreads.clear();
+            },
         });
-        if (thread) {
-          return thread;
-        }
 
-        // If thread not found, it might not be accessible to current user
-        // or wasn't loaded in init_messaging (e.g., old thread, different user)
-        console.warn(`Thread ${threadId} not found in mailStore`);
-        return null;
-      },
-
-      async sendLLMMessage(threadId, content) {
-        if (!threadId || !content?.trim()) return;
-
-        try {
-          // Start LLM streaming - backend will handle both user message creation and AI response
-          await this.startLLMStreaming(threadId, content);
-        } catch (error) {
-          console.error("Error sending LLM message:", error);
-          notification.add(
-            _t(
-              "Could not send your message. Please check your connection and try again."
-            ),
-            { type: "danger" }
-          );
-        }
-      },
-
-      async startLLMStreaming(threadId, message) {
-        // Stop any existing stream for this thread
-        this.stopStreaming(threadId);
-
-        this.streamingThreads.add(threadId);
-
-        try {
-          // Include message parameter only if provided (for user message creation)
-          // If message is null/empty, backend will use latest message in thread
-          const url = message
-            ? `/llm/thread/generate?thread_id=${threadId}&message=${encodeURIComponent(
-                message
-              )}`
-            : `/llm/thread/generate?thread_id=${threadId}`;
-          const eventSource = new EventSource(url);
-
-          this.eventSources.set(threadId, eventSource);
-
-          eventSource.onmessage = (event) => {
-            const data = JSON.parse(event.data);
-            this.handleStreamMessage(threadId, data);
-          };
-
-          eventSource.onerror = (error) => {
-            console.error("EventSource error:", error);
-            this.stopStreaming(threadId);
-            notification.add(
-              _t(
-                "Lost connection to AI service. Please try sending your message again."
-              ),
-              {
-                type: "danger",
-              }
-            );
-          };
-        } catch (error) {
-          console.error("Error starting stream:", error);
-          this.stopStreaming(threadId);
-          notification.add(
-            _t(
-              "Could not start AI response. Please check your connection and try again."
-            ),
-            { type: "danger" }
-          );
-        }
-      },
-
-      stopStreaming(threadId) {
-        const eventSource = this.eventSources.get(threadId);
-        if (eventSource) {
-          eventSource.close();
-          this.eventSources.delete(threadId);
-        }
-        this.streamingThreads.delete(threadId);
-      },
-
-      handleStreamMessage(threadId, data) {
-        switch (data.type) {
-          case "message_create": {
-            // Handle all messages (user and AI) via EventSource
-            mailStore.insert(
-              { "mail.message": [data.message] },
-              { html: true }
-            );
-
-            // Get the created message and add it to the thread's messages collection
-            const createdMessage = mailStore.Message.get(data.message.id);
-
-            // Add message to the correct thread's messages collection (not the active thread)
-            const createThread = mailStore.Thread.get({
-              model: "llm.thread",
-              id: threadId,
-            });
-            if (
-              createThread &&
-              createdMessage &&
-              !createThread.messages.some((m) => m.id === createdMessage.id)
-            ) {
-              createThread.messages.push(createdMessage);
-            }
-            break;
-          }
-
-          case "message_chunk":
-          case "message_update":
-            // Update existing message using standard mail.store.insert() like Odoo does
-            // Use the same pattern as Odoo's standard bus handlers - always use insert
-            // which will update existing messages or create new ones as needed
-            mailStore.insert(
-              { "mail.message": [data.message] },
-              { html: true }
-            );
-            break;
-
-          case "error":
-            console.error("Stream error:", data.error);
-            this.stopStreaming(threadId);
-            notification.add(data.error || _t("AI response error"), {
-              type: "danger",
-            });
-            break;
-
-          case "done":
-            this.stopStreaming(threadId);
-            break;
-
-          case "tool_called":
-          case "tool_succeeded":
-          case "tool_failed":
-            // No-op: handled via message_update
-            console.log("[LLM] no-op event:", data.type);
-            break;
-
-          default:
-            console.warn("Unknown stream message type:", data.type);
-            break;
-        }
-      },
-
-      async loadLLMModels() {
-        try {
-          // Check if llm.model exists first - use correct field names
-          const models = await orm.searchRead(
-            "llm.model",
-            [["active", "=", true]],
-            ["id", "name", "provider_id", "default", "model_use"]
-          );
-
-          models.forEach((model) => {
-            this.llmModels.set(model.id, model);
-          });
-        } catch (error) {
-          console.warn(
-            "LLM models not available - llm module may not be installed:",
-            error.message
-          );
-          // Don't throw error, just log warning
-        }
-      },
-
-      async loadLLMProviders() {
-        try {
-          // Check if llm.provider exists first - use correct field names
-          const providers = await orm.searchRead(
-            "llm.provider",
-            [["active", "=", true]],
-            ["id", "name", "service"]
-          );
-
-          providers.forEach((provider) => {
-            this.llmProviders.set(provider.id, provider);
-          });
-        } catch (error) {
-          console.warn(
-            "LLM providers not available - llm module may not be installed:",
-            error.message
-          );
-          // Don't throw error, just log warning
-        }
-      },
-
-      async loadLLMTools() {
-        // Load available tools with minimal fields
-        const tools = await orm.searchRead(
-          "llm.tool",
-          [["active", "=", true]],
-          ["id", "name"]
-        );
-
-        tools.forEach((tool) => {
-          this.llmTools.set(tool.id, tool);
-        });
-      },
-
-      // Thread selection using standard Odoo patterns
-      async selectThread(threadId) {
-        try {
-          // Ensure thread is loaded using standard fetchData
-          const thread = await this.ensureThreadLoaded(threadId);
-          if (!thread) {
-            throw new Error("Thread not found or failed to load");
-          }
-
-          // Set as active thread in discuss - this is all we need!
-          thread.setAsDiscussThread();
-        } catch (error) {
-          console.error("Error selecting thread:", error);
-          notification.add(
-            _t(
-              "Could not load this conversation. It may have been deleted or you may not have access."
-            ),
-            { type: "danger" }
-          );
-        }
-      },
-
-      // Create new thread with default provider and model
-      async createNewThread({ recordModel, recordId } = {}) {
-        // Get first available provider and model
-        const firstProvider = this.getFirstAvailableProvider();
-        const firstModel = this.getFirstAvailableModel();
-
-        // Check for null values and show notifications
-        if (!firstProvider) {
-          notification.add(
-            _t(
-              "No AI providers are configured. Please contact your administrator to set up an AI provider."
-            ),
-            { type: "danger" }
-          );
-          return;
-        }
-
-        if (!firstModel) {
-          notification.add(
-            _t(
-              "No AI models are available. Please contact your administrator to configure AI models."
-            ),
-            { type: "danger" }
-          );
-          return;
-        }
-
-        // Create thread with auto-generated name
-        const threadName = `Chat ${new Date().toLocaleString()}`;
-
-        const threadData = {
-          name: threadName,
-          provider_id: firstProvider.id,
-          model_id: firstModel.id,
-        };
-
-        // Auto-link to record if context provided (e.g., from chatter)
-        if (recordModel && recordId) {
-          threadData.model = recordModel;
-          threadData.res_id = recordId;
-        }
-
-        const threadId = await orm.call("llm.thread", "create", [threadData]);
-
-        // Reload user threads and select the new one
-        await this.refreshThreadsAndSelect(threadId);
-      },
-
-      // Get first available provider
-      getFirstAvailableProvider() {
-        const providers = Array.from(this.llmProviders.values());
-        return providers.length > 0 ? providers[0] : null;
-      },
-
-      // Get first available model
-      getFirstAvailableModel() {
-        const models = Array.from(this.llmModels.values());
-        return models.length > 0 ? models[0] : null;
-      },
-
-      // Refresh threads and select specific thread
-      async refreshThreadsAndSelect(threadId) {
-        // Use proper fetchData to refresh thread data
-        // Will trigger proper reload of all threads
-        await mailStore.fetchData({
-          init_messaging: {},
+        // Initialize LLM data after mailStore is ready (which calls init_messaging)
+        mailStore.isReady.then(() => {
+            llmStore.initialize();
         });
 
-        // Wait a moment for threads to be populated
-        await new Promise((resolve) => setTimeout(resolve, 100));
+        // NOTE: No longer need thread subscription since threads load automatically via fetchData
 
-        // Select the newly created thread
-        await this.selectThread(threadId);
-      },
-
-      // Link a record to a thread
-      async linkRecordToThread(threadId, model, recordId) {
-        try {
-          // Update database
-          await orm.write("llm.thread", [threadId], {
-            model: model,
-            res_id: recordId,
-          });
-
-          // Update the thread object in mailStore for immediate reactivity
-          const thread = mailStore.Thread.get({
-            model: "llm.thread",
-            id: threadId,
-          });
-
-          if (thread) {
-            Object.assign(thread, {
-              res_model: model,
-              res_id: recordId,
-            });
-          }
-
-          notification.add(_t("Record linked to conversation successfully."), {
-            type: "success",
-          });
-          return true;
-        } catch (error) {
-          console.error("Error linking record:", error);
-          notification.add(
-            _t(
-              "Could not link the record to this conversation. Please try again."
-            ),
-            { type: "danger" }
-          );
-          return false;
-        }
-      },
-
-      // Unlink record from a thread
-      async unlinkRecordFromThread(threadId) {
-        try {
-          // Update database
-          await orm.write("llm.thread", [threadId], {
-            model: false,
-            res_id: false,
-          });
-
-          // Update the thread object in mailStore for immediate reactivity
-          const thread = mailStore.Thread.get({
-            model: "llm.thread",
-            id: threadId,
-          });
-
-          if (thread) {
-            Object.assign(thread, {
-              res_model: false,
-              res_id: false,
-            });
-          }
-
-          notification.add(
-            _t("Record unlinked from conversation successfully."),
-            {
-              type: "success",
-            }
-          );
-          return true;
-        } catch (error) {
-          console.error("Error unlinking record:", error);
-          notification.add(
-            _t(
-              "Could not unlink the record from this conversation. Please try again."
-            ),
-            { type: "danger" }
-          );
-          return false;
-        }
-      },
-
-      // Helper methods for components
-      isStreamingThread(threadId) {
-        return this.streamingThreads.has(threadId);
-      },
-
-      getStreamingStatus() {
-        const activeThread = mailStore.discuss?.thread;
-        if (activeThread?.model === "llm.thread") {
-          return this.isStreamingThread(activeThread.id);
-        }
-        return false;
-      },
-
-      // Pending open methods - used by client action to bypass unreliable bus
-      setPendingOpenInChatter(data) {
-        this.pendingOpenInChatter = data;
-      },
-
-      consumePendingOpenInChatter(model, resId) {
-        const pending = this.pendingOpenInChatter;
-        if (pending && pending.model === model && pending.resId === resId) {
-          this.pendingOpenInChatter = null;
-          return pending;
-        }
-        return null;
-      },
-
-      // Get list of data loaders - can be extended by patches
-      getDataLoaders() {
-        return [this.loadLLMProviders, this.loadLLMModels, this.loadLLMTools];
-      },
-
-      // Initialize LLM store - threads now loaded via standard init_messaging
-      async initialize() {
-        try {
-          const loaders = this.getDataLoaders();
-          await Promise.all(loaders.map((loader) => loader.call(this)));
-          // NOTE: LLM threads are now loaded automatically via res.users._init_messaging()
-          this.isReady.resolve();
-        } catch (error) {
-          console.error("Error initializing LLM store:", error);
-          this.isReady.reject(error);
-        }
-      },
-
-      // Cleanup
-      destroy() {
-        // Close all event sources
-        this.eventSources.forEach((eventSource) => eventSource.close());
-        this.eventSources.clear();
-        this.streamingThreads.clear();
-      },
-    });
-
-    // Initialize LLM data after mailStore is ready (which calls init_messaging)
-    mailStore.isReady.then(() => {
-      llmStore.initialize();
-    });
-
-    // NOTE: No longer need thread subscription since threads load automatically via fetchData
-
-    return llmStore;
-  },
+        return llmStore;
+    },
 };
 
 registry.category("services").add("llm.store", llmStoreService);


### PR DESCRIPTION
## Summary
Adds multimodal file attachment support to LLM threads for OpenAI and Anthropic providers.

## Changes
- **llm/models/mail_message.py**: Added MIME type constants and attachment extraction methods (`_get_image_attachments`, `_get_pdf_attachments`, `_get_text_attachments`)
- **llm_openai/models/openai_provider.py**: Fixed vision model detection patterns (gpt-4o, gpt-4-turbo, gpt-4.1, o1, o3)
- **llm_openai/models/mail_message.py**: Format images/PDFs/text for OpenAI API with multimodal check
- **llm_anthropic/models/mail_message.py**: Format images/PDFs/text for Anthropic API with multimodal check
- **llm_thread/controllers/main.py**: Accept `attachment_ids` parameter from frontend
- **llm_thread/models/llm_thread.py**: Pass `attachment_ids` to `message_post()`
- **llm_thread/static/src/**: Frontend patches to extract and send attachment IDs

## Supported File Types
| Type | MIME Types | Handling |
|------|------------|----------|
| Images | jpeg, png, gif, webp | `image_url` block (OpenAI) / `image` block (Anthropic) |
| PDFs | application/pdf | `file` block (OpenAI) / `document` block (Anthropic) |
| Text | txt, md, csv, json, xml, html, css, js, py | Content embedded in message body |

## Important
- Images/PDFs are only sent if the model has `model_use='multimodal'`
- Non-multimodal models will skip visual attachments gracefully