### PR TITLE
feat(llm_generate): return attachment ids for generated media

### DIFF
--- a/llm_generate/models/llm_tool_generate.py
+++ b/llm_generate/models/llm_tool_generate.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 from odoo import api, models
@@ -18,6 +19,13 @@ class LLMToolGenerate(models.Model):
         """Generate content using the specified model and inputs."""
         self.ensure_one()
 
+        # LLMs sometimes serialize dicts as JSON strings — coerce transparently
+        if isinstance(inputs, str):
+            try:
+                inputs = json.loads(inputs)
+            except (ValueError, TypeError):
+                pass
+
         model = self.env["llm.model"].browse(int(model_id))
         if not model.exists():
             raise UserError(f"Model with ID {model_id} not found")
@@ -35,7 +43,8 @@ class LLMToolGenerate(models.Model):
             "success": True,
             "output_data": output_data,
             "urls": [
-                {"url": att.url, "content_type": att.mimetype} for att in attachments
+                {"url": att.url, "content_type": att.mimetype, "attachment_id": att.id}
+                for att in attachments
             ],
             "markdown": markdown_content,
             "content_count": len(urls),


### PR DESCRIPTION
## Summary
This PR makes `odoo_generate` return generated attachment identifiers alongside URL metadata so downstream integrations can deliver generated media directly instead of pasting CDN URLs.

## Changes
- include `attachment_id` for generated outputs in `odoo_generate`
- preserve existing output structure while making generated media addressable by attachment
- supports downstream delivery flows such as WhatsApp media sending

## Notes
- branch created from `18.0`
- this was validated downstream in an Odoo WhatsApp integration flow