### PR TITLE
fix(llm_mistral): support mistralai v2 — Mistral moved to mistralai.client

### DIFF
--- a/llm_mistral/models/mistral_provider.py
+++ b/llm_mistral/models/mistral_provider.py
@@ -2,7 +2,10 @@ import base64
 import logging
 from urllib.parse import urlparse
 
-from mistralai import Mistral
+try:
+    from mistralai import Mistral  # mistralai < 2.0
+except ImportError:
+    from mistralai.client import Mistral  # mistralai >= 2.0
 
 from odoo import _, api, models
 from odoo.exceptions import UserError


### PR DESCRIPTION
## Problem

`mistralai` v2.0 restructured the package as a namespace package with no root `__init__.py`, breaking the existing import:

```python
from mistralai import Mistral  # works in v1.x, fails in v2.x
```

**Error in v2:**
```
ImportError: cannot import name 'Mistral' from 'mistralai' (unknown location)
```

## Fix

Try/except compatibility shim supporting both v1 and v2:

```python
try:
    from mistralai import Mistral  # mistralai < 2.0
except ImportError:
    from mistralai.client import Mistral  # mistralai >= 2.0
```

In `mistralai` v2.x, `Mistral` was moved to `mistralai.client`. The rest of the API (client instantiation, chat, embeddings, OCR) is unchanged.

## Testing

Verified with `mistralai==2.4.3` — `llm_mistral` installs and runs correctly.

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)