### PR TITLE
feat(account_invoice_import_llm): use Mistral Document AI annotations (single API call)

### DIFF
--- a/account_invoice_import_llm/__manifest__.py
+++ b/account_invoice_import_llm/__manifest__.py
@@ -6,7 +6,7 @@
         Extracts invoice data from PDFs and images when embedded XML is not available.
     """,
     "category": "Accounting/AI",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "depends": [
         "account_invoice_import",  # OCA invoice import wizard
         "llm_assistant",  # LLM infrastructure

--- a/account_invoice_import_llm/models/account_invoice_import_ocr.py
+++ b/account_invoice_import_llm/models/account_invoice_import_ocr.py
@@ -19,6 +19,58 @@ class AccountInvoiceImportOCR(models.AbstractModel):
     _name = "account.invoice.import.ocr"
     _description = "Invoice data extraction using LLM and OCR"
 
+    _INVOICE_ANNOTATION_SCHEMA = {
+        "schema": {
+            "type": "object",
+            "title": "InvoiceData",
+            "properties": {
+                "vendorName": {"type": "string", "title": "Vendor Name"},
+                "vat": {"type": "string", "title": "VAT Number"},
+                "invoiceNumber": {"type": "string", "title": "Invoice Number"},
+                "invoiceDate": {"type": "string", "title": "Invoice Date (YYYY-MM-DD)"},
+                "dueDate": {"type": "string", "title": "Due Date (YYYY-MM-DD)"},
+                "currency": {"type": "string", "title": "Currency ISO Code"},
+                "subtotalAmount": {"type": "number", "title": "Subtotal Before Tax"},
+                "taxAmount": {"type": "number", "title": "Tax Amount"},
+                "totalAmount": {"type": "number", "title": "Total Including Tax"},
+                "lines": {
+                    "type": "array",
+                    "title": "Invoice Lines",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "description": {"type": "string", "title": "Description"},
+                            "quantity": {"type": "number", "title": "Quantity"},
+                            "unitPrice": {"type": "number", "title": "Unit Price"},
+                            "lineSubtotal": {
+                                "type": "number",
+                                "title": "Line Subtotal",
+                            },
+                            "taxPercent": {"type": "number", "title": "Tax Percent"},
+                        },
+                        "required": [
+                            "description",
+                            "quantity",
+                            "unitPrice",
+                            "lineSubtotal",
+                        ],
+                        "additionalProperties": False,
+                    },
+                },
+            },
+            "required": [
+                "vendorName",
+                "invoiceNumber",
+                "invoiceDate",
+                "totalAmount",
+                "lines",
+            ],
+            "additionalProperties": False,
+        },
+        "name": "invoice_data",
+        "strict": True,
+    }
+
     @api.model
     def extract_invoice_data(self, file_data, company=None, mimetype="application/pdf"):
         """Extract invoice data from file bytes using OCR + LLM.
@@ -55,24 +107,82 @@ class AccountInvoiceImportOCR(models.AbstractModel):
             'chatter_msg': [],
         }
         """
-        # Step 1: Run OCR directly on file bytes
+        # Fast path: single-call Document AI (OCR + structured extraction)
+        invoice_data = self._run_ocr_with_annotations(file_data, mimetype)
+        if invoice_data is not None:
+            return self._convert_llm_data_to_pivot(invoice_data)
+
+        # Fallback: original OCR → LLM pipeline
         ocr_text = self._run_ocr_on_file_data(file_data, mimetype)
         if not ocr_text:
             raise UserError(
                 _("OCR returned empty text. The document may be unreadable or empty.")
             )
-
-        # Step 2: Render prompt with OCR context
         prepend_messages, assistant = self._render_invoice_extraction_prompt(ocr_text)
-
-        # Step 3: Call LLM directly (no thread)
         llm_response = self._call_llm_for_extraction(prepend_messages, assistant)
-
-        # Step 4: Parse LLM response
         invoice_data = self._parse_llm_response(llm_response)
-
-        # Step 5: Convert to pivot format
         return self._convert_llm_data_to_pivot(invoice_data)
+
+    @api.model
+    def _get_invoice_annotation_schema(self):
+        return self._INVOICE_ANNOTATION_SCHEMA
+
+    @api.model
+    def _run_ocr_with_annotations(self, file_data, mimetype="application/pdf"):
+        """Single-call OCR + Document AI annotation. Returns camelCase dict or None."""
+        provider = self.env["llm.provider"].search(
+            [("service", "=", "mistral")], limit=1
+        )
+        if not provider:
+            return None
+
+        try:
+            ocr_model = provider.mistral_get_default_ocr_model()
+        except Exception:
+            _logger.warning("No OCR model available for annotation path, falling back")
+            return None
+
+        try:
+            ocr_response = provider.process_ocr(
+                model_name=ocr_model.name,
+                data=file_data,
+                mimetype=mimetype,
+                annotation_schema=self._get_invoice_annotation_schema(),
+            )
+        except Exception:
+            _logger.exception("Mistral annotation OCR call failed, falling back")
+            return None
+
+        annotation_str = getattr(ocr_response, "document_annotation", None)
+        if not annotation_str:
+            _logger.info(
+                "No document_annotation returned; falling back to OCR+LLM pipeline"
+            )
+            return None
+
+        try:
+            invoice_data = json.loads(annotation_str)
+        except json.JSONDecodeError:
+            _logger.warning(
+                "Failed to parse document_annotation JSON, falling back. Raw: %.200s",
+                annotation_str,
+            )
+            return None
+
+        if not isinstance(invoice_data, dict) or not invoice_data.get("invoiceNumber"):
+            _logger.warning(
+                "document_annotation missing required fields, falling back. Keys: %s",
+                list(invoice_data.keys())
+                if isinstance(invoice_data, dict)
+                else type(invoice_data),
+            )
+            return None
+
+        _logger.info(
+            "Document AI annotation succeeded for invoice %s",
+            invoice_data.get("invoiceNumber", "unknown"),
+        )
+        return invoice_data
 
     @api.model
     def _run_ocr_on_file_data(self, file_data, mimetype="application/pdf"):

--- a/llm_mistral/models/mistral_provider.py
+++ b/llm_mistral/models/mistral_provider.py
@@ -236,11 +236,19 @@ class LLMProvider(models.Model):
         # Call the actual method that interacts with the Mistral API
         return self._process_ocr(model_name, payload, **kwargs)
 
-    def _process_ocr(self, model_name, payload):
+    def _process_ocr(self, model_name, payload, annotation_schema=None):
         mistral_client = self._get_mistral_client()
-        return mistral_client.ocr.process(
-            model=model_name, document=payload, include_image_base64=True
-        )
+        kwargs = {
+            "model": model_name,
+            "document": payload,
+            "include_image_base64": True,
+        }
+        if annotation_schema is not None:
+            kwargs["document_annotation_format"] = {
+                "type": "json_schema",
+                "json_schema": annotation_schema,
+            }
+        return mistral_client.ocr.process(**kwargs)
 
 
 def is_base64_string(data_string):


### PR DESCRIPTION
## Summary

Implements the feature requested in #232 — replaces the current two-step OCR→LLM pipeline with Mistral's Document AI Annotations API for invoice extraction.

### Before (2 API calls)
```
PDF/image → Mistral OCR → markdown text → LLM (Claude/GPT) chat → JSON
```

### After (1 API call)
```
PDF/image + JSON schema → Mistral OCR with document_annotation_format → structured JSON
```

## Changes

### `llm_mistral/models/mistral_provider.py`
- Extended `_process_ocr()` to accept an optional `annotation_schema` parameter
- When provided, passes it as `document_annotation_format` to the Mistral SDK

### `account_invoice_import_llm/models/account_invoice_import_ocr.py`
- Added `_INVOICE_ANNOTATION_SCHEMA` class constant — JSON schema matching the existing camelCase extraction format
- Added `_get_invoice_annotation_schema()` — overridable accessor following Odoo patterns
- Added `_run_ocr_with_annotations()` — attempts the single-call Document AI path with 5 defensive fallback guards
- Modified `extract_invoice_data()` — tries Document AI first, automatically falls back to the existing OCR+LLM pipeline on any failure

## Fallback Behavior

The implementation is fully backward-compatible. `_run_ocr_with_annotations()` returns `None` and the existing pipeline runs unchanged when:
- No Mistral provider is configured
- No OCR model is available
- The Mistral API call fails (network error, auth, etc.)
- `response.document_annotation` is empty or `None`
- The annotation JSON fails to parse
- Required fields are missing from the extracted data

## Testing

Tested manually with PNG invoices on Odoo 18.0:
- Document AI path: single POST to `https://api.mistral.ai/v1/ocr`, `document_annotation` returned and parsed — invoice fields populated correctly
- Fallback path: with `document_annotation=None`, existing OCR→LLM pipeline runs unchanged
- No assistant model required for the Document AI path

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)