### PR TITLE
fix: resolve Odoo 18.0 startup warnings

### DIFF
--- a/llm_mcp_server/security/ir.model.access.csv
+++ b/llm_mcp_server/security/ir.model.access.csv
@@ -1,8 +1,8 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_llm_mcp_server_config_manager,llm.mcp.server.config manager,model_llm_mcp_server_config,llm.group_llm_manager,1,1,1,1
 access_llm_mcp_server_config_user,llm.mcp.server.config user,model_llm_mcp_server_config,base.group_user,1,0,0,0
-access_llm_mcp_server_config_public,llm.mcp.server.config public,model_llm_mcp_server_config,,1,0,0,0
+access_llm_mcp_server_config_public,llm.mcp.server.config public,model_llm_mcp_server_config,base.group_user,1,0,0,0
 access_llm_mcp_session_manager,llm.mcp.session manager,model_llm_mcp_session,llm.group_llm_manager,1,1,1,1
 access_llm_mcp_session_user,llm.mcp.session user,model_llm_mcp_session,base.group_user,1,1,1,1
-access_llm_mcp_session_public,llm.mcp.session public,model_llm_mcp_session,,1,1,1,0
+access_llm_mcp_session_public,llm.mcp.session public,model_llm_mcp_session,base.group_user,1,1,1,0
 access_llm_mcp_key_show_user,llm.mcp.key.show user,model_llm_mcp_key_show,base.group_user,1,1,1,1

--- a/llm_pgvector/models/llm_knowledge_chunk_embedding.py
+++ b/llm_pgvector/models/llm_knowledge_chunk_embedding.py
@@ -55,6 +55,10 @@ class LLMKnowledgeChunkEmbedding(models.Model):
         ),
     ]
 
+    @api.model
+    def _valid_field_parameter(self, field, name):
+        return name == "dimension" or super()._valid_field_parameter(field, name)
+
     def name_get(self):
         """Override to provide a better display name"""
         result = []


### PR DESCRIPTION
## Summary

- **`llm_pgvector`**: add `_valid_field_parameter` override to allow the `dimension=` parameter on the `PgVector` embedding field — Odoo 18.0 raises a startup warning otherwise
- **`llm_mcp_server`**: assign `base.group_user` to the two public access rules (`llm.mcp.server.config public`, `llm.mcp.session public`) — groupless rules are deprecated in Odoo 18.0

## Test plan
- [ ] Start Odoo 18.0 with `llm_pgvector` and `llm_mcp_server` installed — no startup warnings for these two issues
- [ ] MCP server config and session records remain readable by regular users

🤖 Generated with [Claude Code](https://claude.com/claude-code)