### PR TITLE
[FIX] llm_mcp_server: sudo() pre-auth model reads in MCP dispatcher

### DIFF
--- a/llm_mcp_server/mcp_json_dispatcher.py
+++ b/llm_mcp_server/mcp_json_dispatcher.py
@@ -191,7 +191,7 @@ class MCPJsonRPCDispatcher(JsonRPCDispatcher):
         if method_name and method_name.startswith("test"):
             return
 
-        config = request.env["llm.mcp.server.config"].get_active_config()
+        config = request.env["llm.mcp.server.config"].sudo().get_active_config()
 
         # For stateless mode, no session validation needed
         if config.mode == "stateless":
@@ -202,7 +202,7 @@ class MCPJsonRPCDispatcher(JsonRPCDispatcher):
             if not session_id:
                 raise MCPSessionError("Missing mcp-session-id header", http_status=400)
 
-            session = request.env["llm.mcp.session"].get_session(session_id)
+            session = request.env["llm.mcp.session"].sudo().get_session(session_id)
             if not session:
                 raise MCPSessionError("Session not found", http_status=404)
 


### PR DESCRIPTION
## Summary

- Sudo the two `request.env[...]` reads performed by `MCPJsonRPCDispatcher._validate_session_requirements()`, which runs under the route's `auth="public"` context before any Bearer auth happens.
- Without this, every POST `/mcp` request (starting from `initialize`) raises `AccessError` on `llm.mcp.server.config`, because the Public user has no read access to that model.

Fixes #255 — full reproduction, traceback, and root-cause analysis there.

## Why sudo() at the call site

`_validate_session_requirements()` is intentionally invoked **before** Odoo dispatches to the bearer-authenticated handler. Sudoing at the call site (rather than inside `get_active_config()` / `get_session()`) makes the reason explicit: this is a pre-auth dispatcher context, not a model-level decision.

This mirrors the existing pattern in `llm.mcp.server.config.get_mcp_server_url()`, which already sudoes `ir.config_parameter`.

## Test plan

- [x] Reproduce the original `AccessError` on `initialize` against an Odoo 18 instance with a valid Bearer token for an internal user (group `LLM Manager`).
- [x] Apply the patch, restart Odoo.
- [ ] Re-run the same `initialize` request and verify a normal MCP response with `serverInfo` / `capabilities`.
- [ ] Verify `tools/call` still enforces bearer auth via `@requires_bearer_auth` (unchanged path).
- [ ] Verify stateless mode (`config.mode == "stateless"`) returns early as before.

Repro command:
```bash
curl -sS -X POST https://<host>/mcp \
  -H "Authorization: Bearer <api_key>" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}'
```