### PR TITLE
[FIX] llm_mcp_server: sudo() pre-auth model reads in MCPController

### DIFF
--- a/llm_mcp_server/controllers/mcp_controller.py
+++ b/llm_mcp_server/controllers/mcp_controller.py
@@ -125,7 +125,7 @@ class MCPController(http.Controller):
     # MCP Method Handlers
     def _mcp_initialize(self, params, request_id):
         """Handle initialize method with protocol version validation"""
-        config = request.env["llm.mcp.server.config"].get_active_config()
+        config = request.env["llm.mcp.server.config"].sudo().get_active_config()
 
         # Extract protocol version from headers or params
         requested_version = request.httprequest.headers.get(
@@ -141,7 +141,7 @@ class MCPController(http.Controller):
         )
         # For stateful mode, create new session
         if config.mode == "stateful":
-            session = request.env["llm.mcp.session"].create_new_session()
+            session = request.env["llm.mcp.session"].sudo().create_new_session()
 
             # Store client information in session
             if params.get("clientInfo"):
@@ -167,7 +167,7 @@ class MCPController(http.Controller):
 
         # Get session and transition to initialized state
         if session_id:
-            session = request.env["llm.mcp.session"].get_session(session_id)
+            session = request.env["llm.mcp.session"].sudo().get_session(session_id)
 
             if session and session.state == "initializing":
                 session.transition_to("initialized")
@@ -188,6 +188,7 @@ class MCPController(http.Controller):
         """Handle ping method"""
         return {}
 
+    @requires_bearer_auth
     def _mcp_tools_list(self, params, request_id):
         """Handle tools/list method"""
         return request.env["llm.tool"].get_mcp_tools_list(params=params)
@@ -227,7 +228,7 @@ class MCPController(http.Controller):
     @http.route("/mcp/health", type="http", auth="public", methods=["GET", "POST"])
     def health_check(self):
         """Health check endpoint"""
-        config = request.env["llm.mcp.server.config"].get_active_config()
+        config = request.env["llm.mcp.server.config"].sudo().get_active_config()
         health_data = config.get_health_status_data()
 
         return http.Response(


### PR DESCRIPTION
Following up the dispatcher fix in the previous commit, the controller itself has additional unsudoed reads on ACL-restricted models that run under auth="public":

- _mcp_initialize (line 128): llm.mcp.server.config.get_active_config()
- _mcp_initialize (line 144): llm.mcp.session.create_new_session()
- _mcp_notifications_initialized (line 170): llm.mcp.session.get_session()
- health_check (line 230): llm.mcp.server.config.get_active_config()

All four sudo()ed for the same reason as the dispatcher fix: Public user has no read access on llm.mcp.server.config / llm.mcp.session, so the request crashes before the Bearer token is consumed elsewhere.

Additionally, _mcp_tools_list now requires @requires_bearer_auth. sudo()ing it would let any anonymous caller enumerate the registered MCP tools (information disclosure). Mirroring _mcp_tools_call, the tools list is now only exposed to bearer-authenticated callers.

DELETE /mcp (auth="bearer") and _mcp_tools_call (wrapped by @requires_bearer_auth) are unchanged — they already run as the bearer-authenticated user.

Refs #255